### PR TITLE
(#3) feat: add before/after system report to run command

### DIFF
--- a/bin/mac-ops
+++ b/bin/mac-ops
@@ -23,6 +23,7 @@ source "${MAC_OPS_ROOT}/lib/utils/plist-helper.zsh"
 source "${MAC_OPS_ROOT}/lib/utils/format.zsh"
 source "${MAC_OPS_ROOT}/lib/utils/parallel.zsh"
 source "${MAC_OPS_ROOT}/lib/utils/notify.zsh"
+source "${MAC_OPS_ROOT}/lib/utils/snapshot.zsh"
 source "${MAC_OPS_ROOT}/lib/modules/cache-cleanup.zsh"
 source "${MAC_OPS_ROOT}/lib/modules/tmp-cleanup.zsh"
 source "${MAC_OPS_ROOT}/lib/modules/log-cleanup.zsh"
@@ -122,7 +123,11 @@ _mac_ops_cmd_run() {
   # 6. Emergency purge on disk danger
   mac_ops_emergency_purge || true
 
-  # 7. Initialize global counters
+  # 7. Take before snapshot
+  local snapshot_before
+  snapshot_before=$(mac_ops_take_snapshot)
+
+  # 8. Initialize global counters
   MAC_OPS_CLEANED_COUNT=0
   MAC_OPS_CLEANED_BYTES=0
   MAC_OPS_KILLED_COUNT=0
@@ -132,7 +137,7 @@ _mac_ops_cmd_run() {
   local mod_count=0 mod_bytes=0
   mkdir -p "${stats_dir}" 2>/dev/null
 
-  # 8. Module execution
+  # 9. Module execution
   if [[ -n "${target_module}" ]]; then
     # Run only specified module when --module is given
     if [[ -z "${MAC_OPS_MODULE_MAP[${target_module}]+_}" ]]; then
@@ -198,11 +203,18 @@ _mac_ops_cmd_run() {
   # 10. Release lock
   mac_ops_release_lock
 
-  # 11. Result summary
-  mac_ops_print_summary "${MAC_OPS_CLEANED_COUNT}" "${MAC_OPS_CLEANED_BYTES}" "${MAC_OPS_KILLED_COUNT}"
+  # 11. Take after snapshot
+  local snapshot_after
+  snapshot_after=$(mac_ops_take_snapshot)
 
-  # 12. macOS notification (scheduled mode)
-  mac_ops_notify_completion "${MAC_OPS_CLEANED_COUNT}" "${MAC_OPS_CLEANED_BYTES}" "${MAC_OPS_KILLED_COUNT}"
+  # 12. System report (before/after comparison + cleanup summary)
+  mac_ops_print_report "${snapshot_before}" "${snapshot_after}" "${MAC_OPS_CLEANED_COUNT}" "${MAC_OPS_CLEANED_BYTES}" "${MAC_OPS_KILLED_COUNT}"
+
+  # 13. macOS notification (scheduled mode)
+  local before_disk_pct after_disk_pct
+  before_disk_pct="${snapshot_before%% *}"
+  after_disk_pct="${snapshot_after%% *}"
+  mac_ops_notify_completion "${MAC_OPS_CLEANED_COUNT}" "${MAC_OPS_CLEANED_BYTES}" "${MAC_OPS_KILLED_COUNT}" "${before_disk_pct}" "${after_disk_pct}"
 }
 
 # =============================================================================

--- a/lib/utils/format.zsh
+++ b/lib/utils/format.zsh
@@ -112,6 +112,127 @@ mac_ops_print_summary() {
   echo ""
 }
 
+# Print system report with before/after snapshots and cleanup summary
+# Args: before_snapshot, after_snapshot, cleaned_count, cleaned_bytes, killed_procs
+# Snapshot format: "disk_usage_pct disk_available_bytes mem_used_bytes mem_total_bytes"
+mac_ops_print_report() {
+  local before_snapshot="$1"
+  local after_snapshot="$2"
+  local cleaned_count="$3"
+  local cleaned_bytes="$4"
+  local killed_procs="$5"
+
+  # Parse before snapshot
+  local before_disk_usage before_disk_free before_mem_used before_mem_total
+  read -r before_disk_usage before_disk_free before_mem_used before_mem_total <<< "$before_snapshot"
+
+  # Parse after snapshot
+  local after_disk_usage after_disk_free after_mem_used after_mem_total
+  read -r after_disk_usage after_disk_free after_mem_used after_mem_total <<< "$after_snapshot"
+
+  # Calculate deltas
+  local disk_usage_delta=$(( after_disk_usage - before_disk_usage ))
+  local disk_free_delta=$(( after_disk_free - before_disk_free ))
+  local mem_used_delta=$(( after_mem_used - before_mem_used ))
+
+  # Format bytes for display
+  local before_disk_free_fmt after_disk_free_fmt before_mem_used_fmt after_mem_used_fmt
+  before_disk_free_fmt=$(mac_ops_format_bytes "$before_disk_free")
+  after_disk_free_fmt=$(mac_ops_format_bytes "$after_disk_free")
+  before_mem_used_fmt=$(mac_ops_format_bytes "$before_mem_used")
+  after_mem_used_fmt=$(mac_ops_format_bytes "$after_mem_used")
+
+  local disk_free_delta_abs mem_used_delta_abs
+  if (( disk_free_delta < 0 )); then
+    disk_free_delta_abs=$(( -disk_free_delta ))
+  else
+    disk_free_delta_abs=$disk_free_delta
+  fi
+  if (( mem_used_delta < 0 )); then
+    mem_used_delta_abs=$(( -mem_used_delta ))
+  else
+    mem_used_delta_abs=$mem_used_delta
+  fi
+
+  local disk_free_delta_fmt mem_used_delta_fmt
+  disk_free_delta_fmt=$(mac_ops_format_bytes "$disk_free_delta_abs")
+  mem_used_delta_fmt=$(mac_ops_format_bytes "$mem_used_delta_abs")
+
+  echo ""
+  echo "$(mac_ops_color_bold "=== System Report ===")"
+
+  # Disk usage row with color coding
+  local disk_usage_indicator
+  if (( disk_usage_delta < 0 )); then
+    disk_usage_indicator="$(mac_ops_color_green "↓")"
+  elif (( disk_usage_delta == 0 )); then
+    disk_usage_indicator="="
+  else
+    disk_usage_indicator="$(mac_ops_color_yellow "↑")"
+  fi
+
+  printf "%-12s : %6s   →  %6s   (%s %s%%)\n" \
+    "Disk" \
+    "${before_disk_usage}%" \
+    "${after_disk_usage}%" \
+    "$disk_usage_indicator" \
+    "${disk_usage_delta#-}"
+
+  # Disk free row with color coding
+  local disk_free_indicator
+  if (( disk_free_delta > 0 )); then
+    disk_free_indicator="$(mac_ops_color_green "↑")"
+  elif (( disk_free_delta == 0 )); then
+    disk_free_indicator="="
+  else
+    disk_free_indicator="$(mac_ops_color_yellow "↓")"
+  fi
+
+  printf "%-12s : %9s →  %9s (%s %s)\n" \
+    "Disk Free" \
+    "$before_disk_free_fmt" \
+    "$after_disk_free_fmt" \
+    "$disk_free_indicator" \
+    "$disk_free_delta_fmt"
+
+  # Memory used row with color coding
+  local mem_used_indicator
+  if (( mem_used_delta < 0 )); then
+    mem_used_indicator="$(mac_ops_color_green "↓")"
+  elif (( mem_used_delta == 0 )); then
+    mem_used_indicator="="
+  else
+    mem_used_indicator="$(mac_ops_color_yellow "↑")"
+  fi
+
+  printf "%-12s : %9s →  %9s (%s %s)\n" \
+    "Memory" \
+    "$before_mem_used_fmt" \
+    "$after_mem_used_fmt" \
+    "$mem_used_indicator" \
+    "$mem_used_delta_fmt"
+
+  echo ""
+  echo "$(mac_ops_color_bold "=== Cleanup Summary ===")"
+
+  local formatted_size
+  formatted_size=$(mac_ops_format_bytes "$cleaned_bytes")
+
+  if [[ -n "$cleaned_count" && "$cleaned_count" != "0" ]]; then
+    echo "$(mac_ops_color_green "✓") Files cleaned: ${cleaned_count} items (${formatted_size})"
+  fi
+
+  if [[ -n "$killed_procs" && "$killed_procs" != "0" ]]; then
+    echo "$(mac_ops_color_green "✓") Processes terminated: ${killed_procs} items"
+  fi
+
+  if [[ "$cleaned_count" == "0" && "$killed_procs" == "0" ]]; then
+    echo "$(mac_ops_color_blue "ℹ") No items to clean"
+  fi
+
+  echo ""
+}
+
 # Print table row (aligned 3 columns)
 # Args: col1, col2, col3
 mac_ops_print_table_row() {

--- a/lib/utils/notify.zsh
+++ b/lib/utils/notify.zsh
@@ -19,12 +19,14 @@ mac_ops_notify() {
 }
 
 # Cleanup completion notification
-# Args: cleaned_count, cleaned_bytes, killed_procs
+# Args: cleaned_count, cleaned_bytes, killed_procs, disk_before_pct (optional), disk_after_pct (optional)
 # Do not notify if no items were cleaned (count is 0)
 mac_ops_notify_completion() {
   local cleaned_count="$1"
   local cleaned_bytes="$2"
   local killed_procs="$3"
+  local disk_before_pct="${4:-}"
+  local disk_after_pct="${5:-}"
   local formatted_size
   local message_parts=()
   local message
@@ -42,6 +44,15 @@ mac_ops_notify_completion() {
 
   if [[ -n "$killed_procs" && "$killed_procs" != "0" ]]; then
     message_parts+=("${killed_procs} processes terminated")
+  fi
+
+  if [[ -n "$disk_before_pct" && -n "$disk_after_pct" && "$disk_before_pct" != "$disk_after_pct" ]]; then
+    local disk_change=$((disk_before_pct - disk_after_pct))
+    if (( disk_change > 0 )); then
+      message_parts+=("Disk: ${disk_before_pct}% → ${disk_after_pct}% (${disk_change}% freed)")
+    else
+      message_parts+=("Disk: ${disk_before_pct}% → ${disk_after_pct}%")
+    fi
   fi
 
   # Join message parts

--- a/lib/utils/snapshot.zsh
+++ b/lib/utils/snapshot.zsh
@@ -1,0 +1,42 @@
+# lib/utils/snapshot.zsh
+# System state snapshot utilities for before/after comparison
+
+mac_ops_take_snapshot() {
+  local disk_usage_pct disk_available mem_total mem_used
+
+  # Get disk usage percentage
+  disk_usage_pct=$(mac_ops_get_disk_usage) || disk_usage_pct="0"
+
+  # Get available disk bytes
+  disk_available=$(mac_ops_get_disk_available) || disk_available="0"
+
+  # Get total memory
+  mem_total=$(sysctl -n hw.memsize 2>/dev/null) || mem_total="0"
+
+  # Get used memory from vm_stat
+  mem_used=$(mac_ops_parse_vm_stat) || mem_used="0"
+
+  print -- "$disk_usage_pct $disk_available $mem_used $mem_total"
+}
+
+# Helper function to parse vm_stat and calculate used memory
+mac_ops_parse_vm_stat() {
+  local page_size active wired speculative compressor vm_output
+
+  # Get vm_stat output
+  vm_output=$(vm_stat 2>/dev/null) || return 1
+  [[ -z "$vm_output" ]] && return 1
+
+  # Extract page size from first line (format: "Mach Virtual Memory Statistics: (page size of XXXX bytes)")
+  page_size=$(print -- "$vm_output" | head -1 | grep -oE '[0-9]+' | tail -1) || return 1
+  [[ -z "$page_size" ]] && return 1
+
+  # Extract page counts from vm_stat output
+  active=$(print -- "$vm_output" | grep "Pages active:" | awk '{print $NF}' | tr -d '.') || active="0"
+  wired=$(print -- "$vm_output" | grep "Pages wired down:" | awk '{print $NF}' | tr -d '.') || wired="0"
+  speculative=$(print -- "$vm_output" | grep "Pages speculative:" | awk '{print $NF}' | tr -d '.') || speculative="0"
+  compressor=$(print -- "$vm_output" | grep "Pages occupied by compressor:" | awk '{print $NF}' | tr -d '.') || compressor="0"
+
+  # Calculate used memory: (active + wired + speculative + compressor) * page_size
+  print -- $(( (active + wired + speculative + compressor) * page_size ))
+}


### PR DESCRIPTION
Closes #3

## Changes
- `lib/utils/snapshot.zsh` 신규 — `mac_ops_take_snapshot()` 시스템 상태 캡처 (disk usage%, disk free bytes, memory used/total via `vm_stat`)
- `lib/utils/format.zsh` — `mac_ops_print_report()` before/after 비교 테이블 출력
- `bin/mac-ops` — run flow에 before/after 스냅샷 삽입, `print_report` 호출
- `lib/utils/notify.zsh` — 알림에 디스크 변화 정보 추가 (하위 호환)

## 리포트 출력 예시
```
=== System Report ===
Disk         :     4%   →      4%   (= 0%)
Disk Free    :  613.7 GB →   613.7 GB (↓ 352.0 KB)
Memory       :   20.1 GB →    20.0 GB (↓ 120.6 MB)

=== Cleanup Summary ===
✓ Files cleaned: 29 items (250.8 MB)
```

## Test plan
- [x] `zsh -n` 문법 검증 (4개 파일 모두 통과)
- [x] `bin/mac-ops run --dry-run` 리포트 정상 출력 확인
- [x] 기존 테스트 스위트 통과 (20/22, 실패 2건은 기존 이슈)
- [x] Architect 검증 APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)