### PR TITLE
(#5) chore: update Formula to v1.1.0 and README

### DIFF
--- a/Formula/mac-ops.rb
+++ b/Formula/mac-ops.rb
@@ -1,18 +1,19 @@
 class MacOps < Formula
   desc "macOS system optimization CLI tool"
   homepage "https://github.com/seunggabi/mac-ops"
-  url "https://github.com/seunggabi/mac-ops/archive/refs/tags/v1.0.0.tar.gz"
-  # sha256 will be filled after release
+  url "https://github.com/seunggabi/mac-ops/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "bc55b34bd17326e301d50f7966530602922d5ec7398e4c7d39e304e0b54440ff"
   license "MIT"
 
   depends_on :macos
 
   def install
-    # Install all files preserving directory structure
-    prefix.install "bin", "lib", "config", "launchd"
-
-    # Create symlink for the main executable
-    bin.install_symlink prefix/"bin/mac-ops"
+    libexec.install Dir["*"]
+    (bin/"mac-ops").write <<~EOS
+      #!/bin/zsh
+      exec "#{libexec}/bin/mac-ops" "$@"
+    EOS
+    chmod 0755, bin/"mac-ops"
   end
 
   def caveats

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub stars](https://img.shields.io/github/stars/seunggabi/mac-ops?style=flat&color=yellow)](https://github.com/seunggabi/mac-ops/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/seunggabi/mac-ops/releases)
+[![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)](https://github.com/seunggabi/mac-ops/releases)
 [![macOS](https://img.shields.io/badge/macOS-13%2B-black?logo=apple)](https://github.com/seunggabi/mac-ops)
 [![Open Source Love](https://img.shields.io/badge/Open%20Source-%E2%9D%A4-red)](https://github.com/seunggabi/mac-ops)
 [![Zero Dependencies](https://img.shields.io/badge/dependencies-0-brightgreen)](https://github.com/seunggabi/mac-ops)
@@ -38,7 +38,7 @@ cd mac-ops
 chmod +x bin/mac-ops
 ```
 
-### Homebrew (Coming Soon)
+### Homebrew
 
 ```bash
 brew tap seunggabi/mac-ops
@@ -232,7 +232,8 @@ mac-ops/
 │       ├── format.zsh
 │       ├── notify.zsh
 │       ├── parallel.zsh
-│       └── plist-helper.zsh
+│       ├── plist-helper.zsh
+│       └── snapshot.zsh
 ├── config/                        # Configuration files
 ├── launchd/                       # launchd agents
 ├── scripts/                       # Utility scripts


### PR DESCRIPTION
Closes #5

## Changes
- Formula/mac-ops.rb를 v1.1.0으로 업데이트 (URL, sha256)
- README.md 버전 배지 v1.1.0으로 업데이트
- README.md Homebrew 설치 가이드를 `brew tap` 방식으로 변경
- README.md 프로젝트 구조에 snapshot.zsh 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)