### PR TITLE
chore: cleanup unused code and secure all directories

### DIFF
--- a/lib/core/config.zsh
+++ b/lib/core/config.zsh
@@ -40,10 +40,8 @@ mac_ops_init_dirs() {
       fi
     fi
 
-    # Set log directory to be accessible only by owner
-    if [[ "${dir}" == "${MAC_OPS_LOG_DIR}" ]]; then
-      chmod 700 "${dir}" 2>/dev/null
-    fi
+    # Set directories to be accessible only by owner
+    chmod 700 "${dir}" 2>/dev/null
   done
 
   return 0


### PR DESCRIPTION
## Summary
- `lib/core/config.zsh`: chmod 700을 log 디렉토리만이 아닌 모든 mac-ops 디렉토리에 일괄 적용
- 디버깅용 임시 테스트 파일 4개 제거 (`tests/test-timeout-*.zsh`)
- 분석 세션 출력물 `strategy/` 디렉토리 제거

## Test plan
- [ ] `zsh tests/test-modules.zsh` 전체 테스트 통과 확인
- [ ] `zsh tests/test-safety.zsh` 전체 테스트 통과 확인
- [ ] `zsh tests/test-trash.zsh` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)