### PR TITLE
(#18) fix: brew cleanup math expression error and version test hardcoding

### DIFF
--- a/lib/modules/brew-cleanup.zsh
+++ b/lib/modules/brew-cleanup.zsh
@@ -76,7 +76,7 @@ mac_ops_brew_cleanup() {
 
   # Estimate cleaned file count (try to extract from brew cleanup output)
   local cleaned_count
-  cleaned_count=$(echo "${cleanup_output}" | grep -c "Removing:" || echo 0)
+  cleaned_count=$(echo "${cleanup_output}" | grep -c "Removing:" || true)
   MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + cleaned_count))
 
   local freed_mb=$((freed_bytes / 1048576))

--- a/tests/test-modules.zsh
+++ b/tests/test-modules.zsh
@@ -275,7 +275,7 @@ version_output=$("${MAC_OPS_ROOT}/bin/mac-ops" version 2>&1)
 local version_exit=$?
 
 assert_exit_code "${version_exit}" "0" "bin/mac-ops version exits 0"
-assert_output_contains "${version_output}" "v1.0.0" "version output contains 'v1.0.0'"
+assert_output_contains "${version_output}" "mac-ops v" "version output contains 'mac-ops v'"
 
 print ""
 


### PR DESCRIPTION
Closes #18

## Changes
- `brew-cleanup.zsh`: `grep -c || echo 0` → `grep -c || true` (출력 중복 방지)
- `test-modules.zsh`: 버전 테스트 `v1.0.0` → `mac-ops v` 동적 패턴

## Test
- 22/22 passed, 0 failed