### PR TITLE
(#24) chore: migrate homebrew-mac-ops to homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy-homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag version
+        id: tag
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate sha256
+        id: sha
+        run: |
+          TARBALL_URL="https://github.com/seunggabi/mac-ops/archive/refs/tags/${{ steps.tag.outputs.version }}.tar.gz"
+          SHA256=$(curl -sL "$TARBALL_URL" | shasum -a 256 | awk '{print $1}')
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+          echo "tarball_url=$TARBALL_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Update homebrew-tap formula
+        uses: actions/checkout@v4
+        with:
+          repository: seunggabi/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        run: |
+          cd homebrew-tap
+          sed -i 's|url ".*"|url "${{ steps.sha.outputs.tarball_url }}"|' Formula/mac-ops.rb
+          sed -i 's|sha256 ".*"|sha256 "${{ steps.sha.outputs.sha256 }}"|' Formula/mac-ops.rb
+          cat Formula/mac-ops.rb
+
+      - name: Commit and push
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/mac-ops.rb
+          git commit -m "chore: bump mac-ops to ${{ steps.tag.outputs.version }}"
+          git push
+
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ```bash
 # Install via Homebrew
-brew tap seunggabi/mac-ops && brew install mac-ops
+brew install seunggabi/tap/mac-ops
 ```
 
 Or clone from source:

--- a/scripts/deploy-brew.sh
+++ b/scripts/deploy-brew.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # =============================================================================
-# deploy-brew.sh: Deploy latest mac-ops tag to homebrew-mac-ops tap
+# deploy-brew.sh: Deploy latest mac-ops tag to homebrew-tap
 # Usage: ./scripts/deploy-brew.sh
 # =============================================================================
 
@@ -8,14 +8,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MAC_OPS_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-HOMEBREW_REPO="${MAC_OPS_ROOT}/../homebrew-mac-ops"
+HOMEBREW_REPO="${MAC_OPS_ROOT}/../homebrew-tap"
 FORMULA_PATH="${HOMEBREW_REPO}/Formula/mac-ops.rb"
 REPO_URL="https://github.com/seunggabi/mac-ops"
 
-# --- Validate homebrew-mac-ops repo exists ---
+# --- Validate homebrew-tap repo exists ---
 if [[ ! -d "${HOMEBREW_REPO}/.git" ]]; then
-  echo "[ERROR] homebrew-mac-ops repo not found at: ${HOMEBREW_REPO}"
-  echo "  git clone https://github.com/seunggabi/homebrew-mac-ops.git ${HOMEBREW_REPO}"
+  echo "[ERROR] homebrew-tap repo not found at: ${HOMEBREW_REPO}"
+  echo "  git clone https://github.com/seunggabi/homebrew-tap.git ${HOMEBREW_REPO}"
   exit 1
 fi
 
@@ -68,4 +68,4 @@ git add Formula/mac-ops.rb
 git commit -m "chore: bump formula to ${LATEST_TAG}"
 git push origin main
 
-echo "[DONE] homebrew-mac-ops updated to ${LATEST_TAG}"
+echo "[DONE] homebrew-tap updated to ${LATEST_TAG}"


### PR DESCRIPTION
Closes #24

## Changes
- `README.md`: brew 설치 명령어 `seunggabi/tap/mac-ops`로 변경
- `scripts/deploy-brew.sh`: `homebrew-mac-ops` → `homebrew-tap` 경로 전환
- `.github/workflows/release.yml`: `v*` 태그 푸시 시 자동 homebrew formula 업데이트 + GitHub Release 생성

## Setup 필요
- `HOMEBREW_TAP_TOKEN` secret 추가 (homebrew-tap repo Contents 권한 필요)