### PR TITLE
(#32) feat: user ignore file, monitor module, orphan-app safety improvements

### DIFF
--- a/bin/mac-ops
+++ b/bin/mac-ops
@@ -18,6 +18,7 @@ source "${MAC_OPS_ROOT}/lib/core/logger.zsh"
 source "${MAC_OPS_ROOT}/lib/core/lock.zsh"
 source "${MAC_OPS_ROOT}/lib/core/trash.zsh"
 source "${MAC_OPS_ROOT}/lib/core/safety.zsh"
+source "${MAC_OPS_ROOT}/lib/core/ignore.zsh"
 source "${MAC_OPS_ROOT}/lib/core/disk.zsh"
 source "${MAC_OPS_ROOT}/lib/utils/plist-helper.zsh"
 source "${MAC_OPS_ROOT}/lib/utils/format.zsh"
@@ -35,6 +36,7 @@ source "${MAC_OPS_ROOT}/lib/modules/dev-cleanup.zsh"
 source "${MAC_OPS_ROOT}/lib/modules/docker-cleanup.zsh"
 source "${MAC_OPS_ROOT}/lib/modules/browser-cleanup.zsh"
 source "${MAC_OPS_ROOT}/lib/modules/analyze.zsh"
+source "${MAC_OPS_ROOT}/lib/modules/monitor.zsh"
 
 # --- Version (from git tag or VERSION file) ---
 if [[ -d "${MAC_OPS_ROOT}/.git" ]]; then
@@ -76,6 +78,10 @@ Usage:
 Commands:
   run              Run cleanup (default command)
   analyze          Disk space analysis report
+  monitor          Memory & CPU usage dashboard (7-day history)
+  monitor top [N]  Show top N processes by memory (default: 10)
+  monitor kill [M] Kill processes using more than M MB (default: 500)
+  monitor collect  Record a snapshot (use for scheduled collection)
   status           Show trash status and disk usage
   restore <path>   Restore from trash to original location
   list-trash       List trash contents
@@ -146,7 +152,10 @@ _mac_ops_cmd_run() {
   local mod_count=0 mod_bytes=0
   mkdir -p "${stats_dir}" 2>/dev/null
 
-  # 9. Module execution
+  # 9. Load user ignore rules (before any module runs)
+  mac_ops_ignore_load
+
+  # 10. Module execution
   if [[ -n "${target_module}" ]]; then
     # Run only specified module when --module is given
     if [[ -z "${MAC_OPS_MODULE_MAP[${target_module}]+_}" ]]; then
@@ -367,6 +376,37 @@ _mac_ops_cmd_analyze() {
 }
 
 # =============================================================================
+# monitor command
+# =============================================================================
+_mac_ops_cmd_monitor() {
+  mac_ops_init_dirs
+  mac_ops_load_config
+
+  local subcmd="${1:-show}"
+  shift 2>/dev/null || true
+
+  case "${subcmd}" in
+    show|--hours|-h)
+      mac_ops_monitor_show "${subcmd}"
+      ;;
+    top)
+      mac_ops_monitor_top "${1:-10}"
+      ;;
+    kill)
+      mac_ops_monitor_kill "${1:-${MAC_OPS_MONITOR_KILL_THRESHOLD_MB:-500}}"
+      ;;
+    collect)
+      mac_ops_monitor_collect
+      mac_ops_log_info "Monitor snapshot collected"
+      ;;
+    *)
+      # treat unknown subcommand as flag to show (e.g., --hours passed first)
+      mac_ops_monitor_show "${subcmd}"
+      ;;
+  esac
+}
+
+# =============================================================================
 # config command
 # =============================================================================
 _mac_ops_cmd_config() {
@@ -401,6 +441,7 @@ _mac_ops_main() {
   local command="run"
   local module_name=""
   local restore_path=""
+  local -a monitor_subcmd=()
 
   # Parse arguments
   while [[ $# -gt 0 ]]; do
@@ -408,6 +449,13 @@ _mac_ops_main() {
       run|analyze|status|list-trash|purge|install|uninstall|config|help|version)
         command="${1}"
         shift
+        ;;
+      monitor)
+        command="monitor"
+        shift
+        # Capture remaining args as monitor subcommand (top/kill/collect/--hours)
+        monitor_subcmd=("$@")
+        set --  # clear positional params to end the while loop
         ;;
       restore)
         command="restore"
@@ -461,6 +509,9 @@ _mac_ops_main() {
       ;;
     analyze)
       _mac_ops_cmd_analyze
+      ;;
+    monitor)
+      _mac_ops_cmd_monitor "${monitor_subcmd[@]}"
       ;;
     status)
       _mac_ops_cmd_status

--- a/config/default.plist
+++ b/config/default.plist
@@ -50,7 +50,12 @@
 		<key>dev-cleanup</key>
 		<dict>
 			<key>Enabled</key>
-			<true/>
+			<false/>
+		</dict>
+		<key>browser-cleanup</key>
+		<dict>
+			<key>Enabled</key>
+			<false/>
 		</dict>
 		<key>docker-cleanup</key>
 		<dict>

--- a/config/ignore.example
+++ b/config/ignore.example
@@ -1,0 +1,39 @@
+# mac-ops ignore file
+# Copy this file to ~/.mac-ops/ignore and customize as needed.
+#
+# Lines starting with # are comments. Empty lines are ignored.
+#
+# Sections:
+#   [bundle]   Bundle ID patterns → skipped by orphan-app-cleanup
+#   [process]  Process name patterns → skipped by zombie-killer, orphan-killer
+#   [path]     Path patterns → skipped by all file-based cleanups
+#
+# Pattern syntax:
+#   Exact match:      com.mycompany.MyApp
+#   Prefix wildcard:  com.mycompany.*
+#   Glob wildcard:    MyHelper*
+#   Path with glob:   ~/work/project/**
+
+# ---------------------------------------------------------------------------
+[bundle]
+# My company's apps
+# com.mycompany.*
+
+# A specific app not in /Applications (e.g., sideloaded build)
+# com.example.DevBuild
+
+# ---------------------------------------------------------------------------
+[process]
+# A background daemon you manage manually
+# my-custom-daemon
+
+# All helper processes from a specific vendor
+# MyVendorHelper*
+
+# ---------------------------------------------------------------------------
+[path]
+# A custom cache directory that mac-ops should never touch
+# ~/work/.cache
+
+# A project with large node_modules you manage yourself
+# ~/projects/my-project

--- a/lib/core/ignore.zsh
+++ b/lib/core/ignore.zsh
@@ -1,0 +1,136 @@
+# =============================================================================
+# mac-ops: User ignore rules loader
+# Reads ~/.mac-ops/ignore and populates rule arrays for bundle IDs, processes, and paths.
+#
+# File format (~/.mac-ops/ignore):
+#   # Comments start with #
+#   [bundle]    Bundle ID patterns for orphan-app-cleanup
+#   [process]   Process name patterns for zombie-killer, orphan-killer
+#   [path]      Path patterns for all file-based cleanups
+#
+# Pattern syntax:
+#   - Exact match:       com.mycompany.MyApp
+#   - Prefix wildcard:   com.mycompany.*
+#   - Glob wildcard:     MyHelper*
+#   - Path with glob:    ~/work/project/**
+# =============================================================================
+
+# --- Global ignore rule arrays (populated by mac_ops_ignore_load) ---
+typeset -ga _MAC_OPS_IGNORE_BUNDLES
+typeset -ga _MAC_OPS_IGNORE_PROCESSES
+typeset -ga _MAC_OPS_IGNORE_PATHS
+_MAC_OPS_IGNORE_BUNDLES=()
+_MAC_OPS_IGNORE_PROCESSES=()
+_MAC_OPS_IGNORE_PATHS=()
+
+# -----------------------------------------------------------------------------
+# Load ignore rules from ~/.mac-ops/ignore
+# Parses [bundle], [process], [path] sections into global arrays.
+# Safe to call multiple times (resets on each call).
+# Usage: mac_ops_ignore_load
+# -----------------------------------------------------------------------------
+mac_ops_ignore_load() {
+  local ignore_file="${MAC_OPS_HOME}/ignore"
+
+  _MAC_OPS_IGNORE_BUNDLES=()
+  _MAC_OPS_IGNORE_PROCESSES=()
+  _MAC_OPS_IGNORE_PATHS=()
+
+  if [[ ! -f "${ignore_file}" ]]; then
+    mac_ops_log_debug "No ignore file: ${ignore_file}"
+    return 0
+  fi
+
+  local current_section=""
+  local line
+
+  while IFS= read -r line; do
+    # Strip inline comments
+    line="${line%%\#*}"
+
+    # Trim leading/trailing whitespace
+    line="${line##[[:space:]]#}"
+    line="${line%%[[:space:]]#}"
+
+    # Skip empty lines
+    [[ -z "${line}" ]] && continue
+
+    # Section header: [bundle], [process], [path]
+    if [[ "${line}" == \[*\] ]]; then
+      current_section="${line:1:-1}"
+      continue
+    fi
+
+    # Expand ~ to $HOME in path patterns
+    local expanded="${line/#\~/${HOME}}"
+
+    case "${current_section}" in
+      bundle)   _MAC_OPS_IGNORE_BUNDLES+=("${expanded}")   ;;
+      process)  _MAC_OPS_IGNORE_PROCESSES+=("${expanded}") ;;
+      path)     _MAC_OPS_IGNORE_PATHS+=("${expanded}")     ;;
+      *)
+        mac_ops_log_debug "Ignore file: unknown section '${current_section}', skipping: ${line}"
+        ;;
+    esac
+  done < "${ignore_file}"
+
+  mac_ops_log_debug "Ignore rules loaded — bundle: ${#_MAC_OPS_IGNORE_BUNDLES[@]}, process: ${#_MAC_OPS_IGNORE_PROCESSES[@]}, path: ${#_MAC_OPS_IGNORE_PATHS[@]}"
+}
+
+# -----------------------------------------------------------------------------
+# Check if a bundle ID should be ignored by user rules
+# Returns 0 (match = ignore), 1 (no match = proceed)
+# Supports exact match and glob patterns (com.mycompany.*, MyApp*)
+# Usage: mac_ops_ignore_check_bundle <bundle_id>
+# -----------------------------------------------------------------------------
+mac_ops_ignore_check_bundle() {
+  local name="${1}"
+  local pattern
+  for pattern in "${_MAC_OPS_IGNORE_BUNDLES[@]}"; do
+    # ${~pattern} enables glob expansion in the pattern
+    if [[ "${name}" == ${~pattern} ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# Check if a process name should be ignored by user rules
+# Returns 0 (match = ignore), 1 (no match = proceed)
+# Supports exact match and glob patterns (MyDaemon, MyHelper*)
+# Usage: mac_ops_ignore_check_process <process_name>
+# -----------------------------------------------------------------------------
+mac_ops_ignore_check_process() {
+  local name="${1}"
+  local pattern
+  for pattern in "${_MAC_OPS_IGNORE_PROCESSES[@]}"; do
+    if [[ "${name}" == ${~pattern} ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# Check if a filesystem path should be ignored by user rules
+# Returns 0 (match = ignore), 1 (no match = proceed)
+# Supports exact path, prefix (~/work/**), and glob patterns
+# Usage: mac_ops_ignore_check_path <absolute_path>
+# -----------------------------------------------------------------------------
+mac_ops_ignore_check_path() {
+  local target="${1}"
+  local pattern
+  for pattern in "${_MAC_OPS_IGNORE_PATHS[@]}"; do
+    # Exact or glob match
+    if [[ "${target}" == ${~pattern} ]]; then
+      return 0
+    fi
+    # Prefix directory match: if pattern is /foo/bar, also protect /foo/bar/child
+    local base="${pattern%/}"
+    if [[ "${target}" == "${base}/"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/lib/modules/dev-cleanup.zsh
+++ b/lib/modules/dev-cleanup.zsh
@@ -3,6 +3,10 @@
 # Integrated cleanup for Xcode, npm, yarn, pnpm, pip, gradle, CocoaPods, etc.
 # =============================================================================
 
+# --- Default settings ---
+# Only delete cache items older than this many days (prevents wiping active caches)
+MAC_OPS_DEV_CACHE_MAX_AGE_DAYS=${MAC_OPS_DEV_CACHE_MAX_AGE_DAYS:-30}
+
 # -----------------------------------------------------------------------------
 # Xcode cache cleanup
 # DerivedData, Archives, CoreSimulator cache
@@ -140,14 +144,29 @@ _mac_ops_dev_npm() {
 
   mac_ops_log_info "Cleaning npm cache..."
 
+  local _dev_now _dev_max_age_s _dev_cleaned=0
+  _dev_now=$(date +%s)
+  _dev_max_age_s=$((MAC_OPS_DEV_CACHE_MAX_AGE_DAYS * 86400))
+
   for item in "${npm_cache}"/*; do
     [[ ! -e "${item}" ]] && continue
-    mac_ops_trash_move "${item}" "npm cache cleanup" "dev-cleanup"
+    local _dev_mtime _dev_sz
+    _dev_mtime=$(stat -f%m "${item}" 2>/dev/null || echo 0)
+    if [[ $((_dev_now - _dev_mtime)) -lt ${_dev_max_age_s} ]]; then
+      mac_ops_log_debug "Skipping recent npm cache: $(basename ${item})"
+      continue
+    fi
+    _dev_sz=$(mac_ops_get_dir_size "${item}")
+    if mac_ops_trash_move "${item}" "npm cache cleanup" "dev-cleanup"; then
+      _dev_cleaned=$((_dev_cleaned + _dev_sz))
+    fi
   done
 
-  MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + cache_size))
-  MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
-  mac_ops_log_info "npm cache cleanup completed: $(mac_ops_format_bytes ${cache_size})"
+  if [[ ${_dev_cleaned} -gt 0 ]]; then
+    MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + _dev_cleaned))
+    MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
+    mac_ops_log_info "npm cache cleanup completed: $(mac_ops_format_bytes ${_dev_cleaned})"
+  fi
 
   return 0
 }
@@ -183,14 +202,29 @@ _mac_ops_dev_yarn() {
 
   mac_ops_log_info "Cleaning yarn cache..."
 
+  local _dev_now _dev_max_age_s _dev_cleaned=0
+  _dev_now=$(date +%s)
+  _dev_max_age_s=$((MAC_OPS_DEV_CACHE_MAX_AGE_DAYS * 86400))
+
   for item in "${yarn_cache}"/*; do
     [[ ! -e "${item}" ]] && continue
-    mac_ops_trash_move "${item}" "yarn cache cleanup" "dev-cleanup"
+    local _dev_mtime _dev_sz
+    _dev_mtime=$(stat -f%m "${item}" 2>/dev/null || echo 0)
+    if [[ $((_dev_now - _dev_mtime)) -lt ${_dev_max_age_s} ]]; then
+      mac_ops_log_debug "Skipping recent yarn cache: $(basename ${item})"
+      continue
+    fi
+    _dev_sz=$(mac_ops_get_dir_size "${item}")
+    if mac_ops_trash_move "${item}" "yarn cache cleanup" "dev-cleanup"; then
+      _dev_cleaned=$((_dev_cleaned + _dev_sz))
+    fi
   done
 
-  MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + cache_size))
-  MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
-  mac_ops_log_info "yarn cache cleanup completed: $(mac_ops_format_bytes ${cache_size})"
+  if [[ ${_dev_cleaned} -gt 0 ]]; then
+    MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + _dev_cleaned))
+    MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
+    mac_ops_log_info "yarn cache cleanup completed: $(mac_ops_format_bytes ${_dev_cleaned})"
+  fi
 
   return 0
 }
@@ -226,14 +260,29 @@ _mac_ops_dev_pnpm() {
 
   mac_ops_log_info "Cleaning pnpm store..."
 
+  local _dev_now _dev_max_age_s _dev_cleaned=0
+  _dev_now=$(date +%s)
+  _dev_max_age_s=$((MAC_OPS_DEV_CACHE_MAX_AGE_DAYS * 86400))
+
   for item in "${pnpm_store}"/*; do
     [[ ! -e "${item}" ]] && continue
-    mac_ops_trash_move "${item}" "pnpm store cleanup" "dev-cleanup"
+    local _dev_mtime _dev_sz
+    _dev_mtime=$(stat -f%m "${item}" 2>/dev/null || echo 0)
+    if [[ $((_dev_now - _dev_mtime)) -lt ${_dev_max_age_s} ]]; then
+      mac_ops_log_debug "Skipping recent pnpm store: $(basename ${item})"
+      continue
+    fi
+    _dev_sz=$(mac_ops_get_dir_size "${item}")
+    if mac_ops_trash_move "${item}" "pnpm store cleanup" "dev-cleanup"; then
+      _dev_cleaned=$((_dev_cleaned + _dev_sz))
+    fi
   done
 
-  MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + store_size))
-  MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
-  mac_ops_log_info "pnpm store cleanup completed: $(mac_ops_format_bytes ${store_size})"
+  if [[ ${_dev_cleaned} -gt 0 ]]; then
+    MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + _dev_cleaned))
+    MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
+    mac_ops_log_info "pnpm store cleanup completed: $(mac_ops_format_bytes ${_dev_cleaned})"
+  fi
 
   return 0
 }
@@ -269,14 +318,29 @@ _mac_ops_dev_pip() {
 
   mac_ops_log_info "Cleaning pip cache..."
 
+  local _dev_now _dev_max_age_s _dev_cleaned=0
+  _dev_now=$(date +%s)
+  _dev_max_age_s=$((MAC_OPS_DEV_CACHE_MAX_AGE_DAYS * 86400))
+
   for item in "${pip_cache}"/*; do
     [[ ! -e "${item}" ]] && continue
-    mac_ops_trash_move "${item}" "pip cache cleanup" "dev-cleanup"
+    local _dev_mtime _dev_sz
+    _dev_mtime=$(stat -f%m "${item}" 2>/dev/null || echo 0)
+    if [[ $((_dev_now - _dev_mtime)) -lt ${_dev_max_age_s} ]]; then
+      mac_ops_log_debug "Skipping recent pip cache: $(basename ${item})"
+      continue
+    fi
+    _dev_sz=$(mac_ops_get_dir_size "${item}")
+    if mac_ops_trash_move "${item}" "pip cache cleanup" "dev-cleanup"; then
+      _dev_cleaned=$((_dev_cleaned + _dev_sz))
+    fi
   done
 
-  MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + cache_size))
-  MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
-  mac_ops_log_info "pip cache cleanup completed: $(mac_ops_format_bytes ${cache_size})"
+  if [[ ${_dev_cleaned} -gt 0 ]]; then
+    MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + _dev_cleaned))
+    MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
+    mac_ops_log_info "pip cache cleanup completed: $(mac_ops_format_bytes ${_dev_cleaned})"
+  fi
 
   return 0
 }
@@ -312,14 +376,40 @@ _mac_ops_dev_gradle() {
 
   mac_ops_log_info "Cleaning gradle cache..."
 
+  local _dev_now _dev_max_age_s _dev_cleaned=0
+  _dev_now=$(date +%s)
+  _dev_max_age_s=$((MAC_OPS_DEV_CACHE_MAX_AGE_DAYS * 86400))
+
   for item in "${gradle_cache}"/*; do
     [[ ! -e "${item}" ]] && continue
-    mac_ops_trash_move "${item}" "gradle cache cleanup" "dev-cleanup"
+    local _dev_item_name
+    _dev_item_name=$(basename "${item}")
+
+    # Protect downloaded dependency artifacts (modules-*) from cleanup.
+    # These JARs are shared across all projects and expensive to re-download.
+    # Deleting them causes build failures in offline environments.
+    if [[ "${_dev_item_name}" == modules-* ]]; then
+      mac_ops_log_debug "Skipping gradle dependency artifacts: ${_dev_item_name}"
+      continue
+    fi
+
+    local _dev_mtime _dev_sz
+    _dev_mtime=$(stat -f%m "${item}" 2>/dev/null || echo 0)
+    if [[ $((_dev_now - _dev_mtime)) -lt ${_dev_max_age_s} ]]; then
+      mac_ops_log_debug "Skipping recent gradle cache: ${_dev_item_name}"
+      continue
+    fi
+    _dev_sz=$(mac_ops_get_dir_size "${item}")
+    if mac_ops_trash_move "${item}" "gradle cache cleanup" "dev-cleanup"; then
+      _dev_cleaned=$((_dev_cleaned + _dev_sz))
+    fi
   done
 
-  MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + cache_size))
-  MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
-  mac_ops_log_info "gradle cache cleanup completed: $(mac_ops_format_bytes ${cache_size})"
+  if [[ ${_dev_cleaned} -gt 0 ]]; then
+    MAC_OPS_CLEANED_BYTES=$((MAC_OPS_CLEANED_BYTES + _dev_cleaned))
+    MAC_OPS_CLEANED_COUNT=$((MAC_OPS_CLEANED_COUNT + 1))
+    mac_ops_log_info "gradle cache cleanup completed: $(mac_ops_format_bytes ${_dev_cleaned})"
+  fi
 
   return 0
 }

--- a/lib/modules/monitor.zsh
+++ b/lib/modules/monitor.zsh
@@ -1,0 +1,433 @@
+# =============================================================================
+# mac-ops: Memory & CPU monitoring module
+# 7-day history stored as CSV, CLI table + sparkline visualization
+# Process cleanup by memory threshold
+# =============================================================================
+
+# --- Config ---
+MAC_OPS_MONITOR_DIR="${MAC_OPS_HOME}/monitor"
+MAC_OPS_MONITOR_RETENTION_DAYS=${MAC_OPS_MONITOR_RETENTION_DAYS:-7}
+MAC_OPS_MONITOR_KILL_THRESHOLD_MB=${MAC_OPS_MONITOR_KILL_THRESHOLD_MB:-500}
+
+# Sparkline chars: index 1..8 (zsh arrays are 1-indexed)
+_MAC_OPS_SPARK=('▁' '▂' '▃' '▄' '▅' '▆' '▇' '█')
+
+# =============================================================================
+# Internal helpers
+# =============================================================================
+
+# Get memory stats via vm_stat (fast, no external tools needed)
+# Outputs: "mem_used_bytes mem_total_bytes mem_pct"
+_mac_ops_monitor_mem() {
+  local page_size
+  page_size=$(pagesize 2>/dev/null || echo 4096)
+
+  local vm_out
+  vm_out=$(vm_stat 2>/dev/null)
+
+  local wired active compressed
+  wired=$(awk '/Pages wired down/{gsub(/\./, "", $NF); print $NF+0}' <<< "$vm_out")
+  active=$(awk '/Pages active/{gsub(/\./, "", $NF); print $NF+0}' <<< "$vm_out")
+  compressed=$(awk '/Pages occupied by compressor/{gsub(/\./, "", $NF); print $NF+0}' <<< "$vm_out")
+
+  local total used pct
+  total=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+  used=$(( (wired + active + compressed) * page_size ))
+  pct=$(awk "BEGIN{printf \"%.1f\", ($total>0)?($used/$total*100):0}")
+
+  echo "$used $total $pct"
+}
+
+# Get CPU usage % via top (takes ~1 second sample)
+# Outputs: "cpu_pct"
+# Uses BSD awk-compatible parsing (no gawk extensions)
+_mac_ops_monitor_cpu() {
+  top -l 2 -n 0 2>/dev/null | awk '
+    /CPU usage/ { line=$0 }
+    END {
+      if (!line) { print "0.0"; exit }
+      # "CPU usage: 15.8% user, 5.4% sys, 78.7% idle"
+      # Split by space and match tokens following numeric% values
+      n = split(line, a, " ")
+      user=0; sys=0
+      for (i=1; i<=n; i++) {
+        if (a[i] ~ /user/) { v=a[i-1]; gsub(/[^0-9.]/, "", v); user=v+0 }
+        if (a[i] ~ /sys/)  { v=a[i-1]; gsub(/[^0-9.]/, "", v); sys=v+0 }
+      }
+      printf "%.1f", user+sys
+    }
+  '
+}
+
+# Get local UTC offset in seconds (handles half-hour timezones like IST +0530)
+_mac_ops_monitor_tz_offset() {
+  local z
+  z=$(date +%z)  # e.g., +0900
+  local sign=1
+  [[ "${z:0:1}" == "-" ]] && sign=-1
+  echo $(( sign * (10#${z:1:2} * 3600 + 10#${z:3:2} * 60) ))
+}
+
+# Render sparkline from space-separated float values (0–100 scale)
+# Usage: _mac_ops_monitor_sparkline "63.1 70.2 68.5"
+_mac_ops_monitor_sparkline() {
+  local -a vals=("${(s: :)1}")
+  local result=""
+  local v idx
+  for v in "${vals[@]}"; do
+    idx=$(awk "BEGIN{x=int($v/100*7+0.5); print (x>7)?7:(x<0)?0:x}")
+    result+="${_MAC_OPS_SPARK[$((idx+1))]}"
+  done
+  echo "$result"
+}
+
+# Render a colored horizontal bar
+# Usage: _mac_ops_monitor_bar <pct_float> [width=20]
+# (writes directly to stdout with ANSI codes)
+_mac_ops_monitor_bar() {
+  local pct="${1}"
+  local width="${2:-20}"
+  local filled
+  filled=$(awk "BEGIN{x=int($pct/100*$width+0.5); print (x>$width)?$width:(x<0)?0:x}")
+  local empty=$(( width - filled ))
+
+  local red=$'\033[31m' yellow=$'\033[33m' green=$'\033[32m' reset=$'\033[0m'
+  local color
+  if   awk "BEGIN{exit ($pct < 60)?0:1}"; then color="$green"
+  elif awk "BEGIN{exit ($pct < 80)?0:1}"; then color="$yellow"
+  else color="$red"
+  fi
+
+  printf "%s" "$color"
+  local i
+  for (( i=0; i<filled; i++ )); do printf "█"; done
+  for (( i=0; i<empty; i++ )); do printf "░"; done
+  printf "%s" "$reset"
+}
+
+# Get daily averages from a day's CSV
+# Usage: _mac_ops_monitor_daily_stats <YYYY-MM-DD>
+# Outputs: "mem_avg cpu_avg count"
+_mac_ops_monitor_daily_stats() {
+  local csv="${MAC_OPS_MONITOR_DIR}/${1}.csv"
+  [[ ! -f "$csv" ]] && echo "0 0 0" && return
+  awk -F',' '
+    NR>1 && NF>=5 && $4+0>0 {m+=$4; c+=$5; n++}
+    END {printf "%.1f %.1f %d\n", (n>0)?m/n:0, (n>0)?c/n:0, n+0}
+  ' "$csv"
+}
+
+# Get hourly averages for a day (24 lines: "HH mem_avg cpu_avg")
+# Usage: _mac_ops_monitor_hourly_stats <YYYY-MM-DD>
+_mac_ops_monitor_hourly_stats() {
+  local csv="${MAC_OPS_MONITOR_DIR}/${1}.csv"
+  if [[ ! -f "$csv" ]]; then
+    local h
+    for h in $(seq 0 23); do printf "%02d 0 0\n" "$h"; done
+    return
+  fi
+  local tz_offset
+  tz_offset=$(_mac_ops_monitor_tz_offset)
+  awk -F',' -v tz="$tz_offset" '
+    NR>1 && NF>=5 && $1+0>0 {
+      h = int(($1 + tz) / 3600) % 24
+      if (h < 0) h += 24
+      key = sprintf("%02d", h)
+      ms[key]+=$4; cs[key]+=$5; cnt[key]++
+    }
+    END {
+      for (h=0; h<24; h++) {
+        key=sprintf("%02d",h)
+        if (key in cnt) printf "%s %.1f %.1f\n", key, ms[key]/cnt[key], cs[key]/cnt[key]
+        else             printf "%s 0 0\n", key
+      }
+    }
+  ' "$csv" | sort
+}
+
+# Purge CSV files older than retention period
+_mac_ops_monitor_purge_old() {
+  local cutoff=$(( $(date +%s) - MAC_OPS_MONITOR_RETENTION_DAYS * 86400 ))
+  local f fname epoch
+  for f in "${MAC_OPS_MONITOR_DIR}"/*.csv(N); do
+    fname=$(basename "$f" .csv)
+    epoch=$(date -j -f '%Y-%m-%d' "$fname" +%s 2>/dev/null || echo 0)
+    if [[ $epoch -gt 0 && $epoch -lt $cutoff ]]; then
+      rm -f "$f"
+      mac_ops_log_debug "Monitor: purged old file $f"
+    fi
+  done
+}
+
+# =============================================================================
+# Public: collect snapshot
+# Designed to be called from launchd or cron (e.g., every 5 minutes)
+# =============================================================================
+mac_ops_monitor_collect() {
+  mkdir -p "${MAC_OPS_MONITOR_DIR}"
+
+  local ts mem_used mem_total mem_pct cpu_pct
+  ts=$(date +%s)
+  read -r mem_used mem_total mem_pct <<< "$(_mac_ops_monitor_mem)"
+  cpu_pct=$(_mac_ops_monitor_cpu)
+
+  local date_str csv
+  date_str=$(date '+%Y-%m-%d')
+  csv="${MAC_OPS_MONITOR_DIR}/${date_str}.csv"
+
+  [[ ! -f "$csv" ]] && echo "timestamp,mem_used,mem_total,mem_pct,cpu_pct" > "$csv"
+  echo "${ts},${mem_used},${mem_total},${mem_pct},${cpu_pct}" >> "$csv"
+
+  _mac_ops_monitor_purge_old
+  mac_ops_log_debug "Monitor: snapshot saved (mem=${mem_pct}%, cpu=${cpu_pct}%)"
+}
+
+# =============================================================================
+# Internal: show top N processes by memory
+# =============================================================================
+_mac_ops_monitor_show_top() {
+  local limit="${1:-10}"
+  local red=$'\033[31m' yellow=$'\033[33m' reset=$'\033[0m'
+
+  printf "\033[1m◉ Top %d Processes by Memory\033[0m\n" "$limit"
+  printf "  %s\n" "──────────────────────────────────────────────────────────────────────"
+  printf "  %-8s %-36s %10s %8s\n" "PID" "PROCESS" "MEMORY" "CPU%"
+  printf "  %s\n" "──────────────────────────────────────────────────────────────────────"
+
+  ps -eo pid,rss,pcpu,comm= | tail -n +2 | sort -k2 -rn | \
+  awk -v limit="$limit" -v red="$red" -v yellow="$yellow" -v rst="$reset" '
+    count < limit && $2 > 0 {
+      pid=$1; rss=$2; cpu=$3; cmd=$4
+      n=split(cmd, p, "/"); short=p[n]
+      mem_mb = rss / 1024
+      color = (mem_mb >= 2048) ? red : (mem_mb >= 512) ? yellow : rst
+      if (mem_mb >= 1024)
+        printf "  %-8s %s%-36s%s %7.1f GB %7.1f%%\n", pid, color, short, rst, mem_mb/1024, cpu
+      else
+        printf "  %-8s %s%-36s%s %7.1f MB %7.1f%%\n", pid, color, short, rst, mem_mb, cpu
+      count++
+    }
+  '
+  echo ""
+  printf "  \033[2mTip: 'mac-ops monitor kill [MB]' to terminate high-memory processes\033[0m\n"
+  echo ""
+}
+
+# =============================================================================
+# Public: display monitoring dashboard
+# Usage: mac_ops_monitor_show [--hours]
+# =============================================================================
+mac_ops_monitor_show() {
+  setopt LOCAL_OPTIONS NO_ERR_EXIT
+  local show_hours=false
+  [[ "${1}" == "--hours" || "${1}" == "-h" ]] && show_hours=true
+
+  mac_ops_print_header "       mac-ops Resource Monitor"
+
+  # ── Current Status ─────────────────────────────────────────────────────────
+  printf "\033[1m◉ Current Status\033[0m  %s\n" "$(date '+%Y-%m-%d %H:%M:%S')"
+  printf "  %s\n" "──────────────────────────────────────────────────"
+
+  local mem_used mem_total mem_pct
+  read -r mem_used mem_total mem_pct <<< "$(_mac_ops_monitor_mem)"
+  local mem_used_fmt mem_total_fmt
+  mem_used_fmt=$(mac_ops_format_bytes "$mem_used")
+  mem_total_fmt=$(mac_ops_format_bytes "$mem_total")
+
+  printf "  Memory  ["
+  _mac_ops_monitor_bar "$mem_pct" 20
+  printf "]  %5.1f%%  %s / %s\n" "$mem_pct" "$mem_used_fmt" "$mem_total_fmt"
+
+  printf "  CPU     ["
+  local cpu_pct
+  cpu_pct=$(_mac_ops_monitor_cpu)
+  _mac_ops_monitor_bar "$cpu_pct" 20
+  printf "]  %5.1f%%\n" "$cpu_pct"
+
+  echo ""
+
+  # ── 7-Day History ──────────────────────────────────────────────────────────
+  local no_data=true
+  printf "\033[1m◉ 7-Day History\033[0m"
+  if [[ "$show_hours" == true ]]; then
+    printf "  \033[2m(hourly sparkline, 00:00→23:00)\033[0m"
+  fi
+  echo ""
+  printf "  %s\n" "──────────────────────────────────────────────────────────────────────"
+
+  if [[ "$show_hours" == true ]]; then
+    printf "  %-12s  %7s  %7s  %s\n" "DATE" "MEM AVG" "CPU AVG" "MEMORY (24h)"
+  else
+    printf "  %-12s  %7s  %7s  %5s  %5s\n" "DATE" "MEM AVG" "CPU AVG" "MEM" "CPU"
+  fi
+  printf "  %s\n" "──────────────────────────────────────────────────────────────────────"
+
+  local -a daily_mem_avgs daily_cpu_avgs
+  local today_str
+  today_str=$(date '+%Y-%m-%d')
+
+  # Declare all loop variables once outside the loop to avoid zsh re-declaration output
+  local i date_str day_label mem_avg cpu_avg count today_marker
+  local spark mspark cspark hh hmem hcpu
+  local -a hour_mem_vals
+
+  for (( i = MAC_OPS_MONITOR_RETENTION_DAYS - 1; i >= 0; i-- )); do
+    if [[ $i -eq 0 ]]; then
+      date_str=$(date '+%Y-%m-%d')
+      day_label=$(date '+%m/%d %a')
+    else
+      date_str=$(date -v -${i}d '+%Y-%m-%d')
+      day_label=$(date -v -${i}d '+%m/%d %a')
+    fi
+
+    read -r mem_avg cpu_avg count <<< "$(_mac_ops_monitor_daily_stats "$date_str")"
+    daily_mem_avgs+=("$mem_avg")
+    daily_cpu_avgs+=("$cpu_avg")
+
+    today_marker=""
+    [[ "$date_str" == "$today_str" ]] && today_marker=$'\033[2m ← today\033[0m'
+
+    if [[ "$count" -eq 0 ]]; then
+      if [[ "$show_hours" == true ]]; then
+        printf "  %-12s  %7s  %7s  %s\n" "$day_label" "--" "--" "(no data)"
+      else
+        printf "  %-12s  %7s  %7s  %5s  %5s\n" "$day_label" "--" "--" "" ""
+      fi
+      continue
+    fi
+
+    no_data=false
+
+    if [[ "$show_hours" == true ]]; then
+      hour_mem_vals=()
+      while IFS=' ' read -r hh hmem hcpu; do
+        hour_mem_vals+=("$hmem")
+      done < <(_mac_ops_monitor_hourly_stats "$date_str")
+      spark=$(_mac_ops_monitor_sparkline "${hour_mem_vals[*]}")
+      printf "  %-12s  %6.1f%%  %6.1f%%  %s%b\n" \
+        "$day_label" "$mem_avg" "$cpu_avg" "$spark" "$today_marker"
+    else
+      mspark=$(_mac_ops_monitor_sparkline "$mem_avg")
+      cspark=$(_mac_ops_monitor_sparkline "$cpu_avg")
+      printf "  %-12s  %6.1f%%  %6.1f%%  %5s  %5s%b\n" \
+        "$day_label" "$mem_avg" "$cpu_avg" "$mspark" "$cspark" "$today_marker"
+    fi
+  done
+
+  echo ""
+  if [[ "$no_data" == false ]]; then
+    printf "  Memory 7-day trend: %s\n" "$(_mac_ops_monitor_sparkline "${daily_mem_avgs[*]}")"
+    printf "  CPU    7-day trend: %s\n" "$(_mac_ops_monitor_sparkline "${daily_cpu_avgs[*]}")"
+    echo ""
+    if [[ "$show_hours" == false ]]; then
+      printf "  \033[2mTip: 'mac-ops monitor --hours' for hourly sparkline view\033[0m\n"
+    fi
+  else
+    printf "  \033[2mNo history data yet. Run 'mac-ops monitor collect' to start recording.\033[0m\n"
+    printf "  \033[2mFor automatic collection, see: mac-ops monitor setup\033[0m\n"
+  fi
+  echo ""
+
+  # ── Top Processes ──────────────────────────────────────────────────────────
+  _mac_ops_monitor_show_top 10
+}
+
+# =============================================================================
+# Public: show top processes by memory
+# Usage: mac_ops_monitor_top [N]
+# =============================================================================
+mac_ops_monitor_top() {
+  local limit="${1:-10}"
+  mac_ops_print_header "       mac-ops Top Processes"
+  _mac_ops_monitor_show_top "$limit"
+}
+
+# =============================================================================
+# Public: kill high-memory processes interactively
+# Usage: mac_ops_monitor_kill [threshold_MB]
+# =============================================================================
+mac_ops_monitor_kill() {
+  local threshold_mb="${1:-${MAC_OPS_MONITOR_KILL_THRESHOLD_MB}}"
+
+  mac_ops_print_header "       mac-ops Process Cleanup"
+
+  local proc_list
+  proc_list=$(
+    ps -eo pid,rss,pcpu,comm= | tail -n +2 | sort -k2 -rn | \
+    awk -v thresh="$((threshold_mb * 1024))" '
+      $2 >= thresh && $2 > 0 {
+        pid=$1; rss=$2; cpu=$3; cmd=$4
+        n=split(cmd, p, "/"); short=p[n]
+        printf "%s %.1f %.1f %s\n", pid, rss/1024, cpu, short
+      }
+    '
+  )
+
+  if [[ -z "${proc_list}" ]]; then
+    printf "  \033[32m✓\033[0m No processes using more than %d MB\n\n" "$threshold_mb"
+    return 0
+  fi
+
+  printf "\033[1m◉ Processes using more than %d MB\033[0m\n" "$threshold_mb"
+  printf "  %s\n" "──────────────────────────────────────────────────────────────────────"
+  printf "  %-8s %-36s %10s %8s\n" "PID" "PROCESS" "MEMORY" "CPU%"
+  printf "  %s\n" "──────────────────────────────────────────────────────────────────────"
+
+  local -a candidate_pids
+  local pid mem_mb cpu cmd
+  while IFS=' ' read -r pid mem_mb cpu cmd; do
+    if awk "BEGIN{exit ($mem_mb >= 1024)?0:1}"; then
+      local gb
+      gb=$(awk "BEGIN{printf \"%.1f\", $mem_mb/1024}")
+      printf "  %-8s \033[33m%-36s\033[0m %7s GB %7.1f%%\n" "$pid" "$cmd" "$gb" "$cpu"
+    else
+      printf "  %-8s %-36s %7.1f MB %7.1f%%\n" "$pid" "$cmd" "$mem_mb" "$cpu"
+    fi
+    candidate_pids+=("$pid")
+  done <<< "$proc_list"
+
+  echo ""
+  printf "  Enter PID to kill, \033[1mall\033[0m for all listed, or \033[1mq\033[0m to quit: "
+
+  local input
+  if ! read -r input 2>/dev/null; then
+    echo ""
+    return 0
+  fi
+
+  case "${input}" in
+    q|Q|"")
+      return 0
+      ;;
+    all|ALL)
+      local p
+      for p in "${candidate_pids[@]}"; do
+        local pname
+        pname=$(ps -p "$p" -o comm= 2>/dev/null | awk -F/ '{print $NF}')
+        if mac_ops_is_process_protected "${pname}" 2>/dev/null; then
+          printf "  \033[33m⚠\033[0m  Skipping protected process: %s (PID %s)\n" "$pname" "$p"
+        elif kill -15 "$p" 2>/dev/null; then
+          printf "  \033[32m✓\033[0m  SIGTERM sent to %s (PID %s)\n" "${pname:-unknown}" "$p"
+        else
+          printf "  \033[31m✗\033[0m  Failed to kill PID %s (try with sudo)\n" "$p"
+        fi
+      done
+      ;;
+    *)
+      if [[ "${input}" =~ ^[0-9]+$ ]]; then
+        local pname
+        pname=$(ps -p "$input" -o comm= 2>/dev/null | awk -F/ '{print $NF}')
+        if mac_ops_is_process_protected "${pname}" 2>/dev/null; then
+          printf "  \033[33m⚠\033[0m  Skipping protected process: %s (PID %s)\n" "$pname" "$input"
+        elif kill -15 "$input" 2>/dev/null; then
+          printf "  \033[32m✓\033[0m  SIGTERM sent to %s (PID %s)\n" "${pname:-unknown}" "$input"
+        else
+          printf "  \033[31m✗\033[0m  Failed to kill PID %s (try with sudo)\n" "$input"
+        fi
+      else
+        printf "  \033[31m✗\033[0m  Invalid input: %s\n" "$input"
+      fi
+      ;;
+  esac
+  echo ""
+}

--- a/lib/modules/orphan-app-cleanup.zsh
+++ b/lib/modules/orphan-app-cleanup.zsh
@@ -1,7 +1,7 @@
 # =============================================================================
 # mac-ops: Orphan app data cleanup module
 # Detect and cleanup leftover files from deleted apps (Application Support, Caches, Preferences, etc.)
-# Excludes com.apple.*, Group Containers, files modified within last 7 days
+# Excludes com.apple.*, Group Containers, systemgroup.*, files modified within last 7 days
 # =============================================================================
 
 # --- Default settings ---
@@ -19,8 +19,93 @@ MAC_OPS_ORPHAN_APP_SCAN_DIRS=(
 )
 
 # -----------------------------------------------------------------------------
+# Safety safelist: bundle ID prefixes that must NEVER be deleted regardless of
+# whether detection (mdfind / path scan / launchd) finds the app or not.
+# Acts as a second line of defense. Keep alphabetically sorted per vendor group.
+# -----------------------------------------------------------------------------
+_MAC_OPS_BUNDLE_SAFELIST=(
+  # --- JetBrains (com.jetbrains.* and bare jetbrains.* for helper plists) ---
+  "com.jetbrains."
+  "jetbrains."
+
+  # --- Google / Chromium ---
+  "com.google."
+  "org.chromium."
+
+  # --- Mozilla ---
+  "org.mozilla."
+
+  # --- Microsoft ---
+  "com.microsoft."
+
+  # --- Adobe ---
+  "com.adobe."
+
+  # --- Korean apps ---
+  "com.kakao."
+  "com.naver."
+  "io.naver."
+
+  # --- Korean banking / security software ---
+  # AhnLab V3, TouchEN nxKey, INISAFE CrossWeb EX, etc.
+  "com.ahnlab."
+  "com.initech."
+  "com.raon."
+  "com.softforum."
+  "kr.co."
+
+  # --- Communication ---
+  "com.discord."
+  "com.slack."
+  "com.tinyspeck."
+  "net.whatsapp."
+  "com.spotify."
+  "us.zoom."
+
+  # --- Productivity / Creative ---
+  "com.atlassian."
+  "com.dropbox."
+  "com.figma."
+  "com.notion."
+
+  # --- Developer tools ---
+  "com.brave."
+  "com.cursor."
+  "com.docker."
+  "com.github."
+  "com.sublimetext."
+  "com.visualstudio."
+  "com.xk72."
+  "dev.zed."
+
+  # --- Utilities / Automation ---
+  "com.raycast."
+
+  # --- Virtualization ---
+  "com.parallels."
+  "com.vmware."
+)
+
+# -----------------------------------------------------------------------------
+# Internal: Check if a bundle ID name is in the safelist
+# Returns 0 (true) if protected, 1 (false) if not
+# Usage: _mac_ops_is_safelisted <name>
+# -----------------------------------------------------------------------------
+_mac_ops_is_safelisted() {
+  local name="${1}"
+  local prefix
+  for prefix in "${_MAC_OPS_BUNDLE_SAFELIST[@]}"; do
+    if [[ "${name}" == "${prefix}"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# -----------------------------------------------------------------------------
 # Orphan app data cleanup main function
-# 1. Extract bundle IDs of installed apps from /Applications, ~/Applications
+# 1. Extract bundle IDs of installed apps from /Applications, ~/Applications,
+#    Spotlight (mdfind), Homebrew Cask, and LaunchDaemons/Agents
 # 2. Search for bundle ID pattern directories/files in scan target paths
 # 3. If not in installed apps list, determine as orphan file and cleanup
 # -----------------------------------------------------------------------------
@@ -40,6 +125,15 @@ mac_ops_orphan_app_cleanup() {
     return 1
   fi
 
+  # Stage 1.5: Collect running app bundle IDs for additional protection
+  typeset -gA _MAC_OPS_RUNNING_BUNDLES
+  _MAC_OPS_RUNNING_BUNDLES=()
+  local _running_id
+  while IFS= read -r _running_id; do
+    [[ -n "${_running_id}" ]] && _MAC_OPS_RUNNING_BUNDLES[${_running_id}]=1
+  done < <(lsappinfo list 2>/dev/null | grep 'bundleID=' | sed 's/.*bundleID="\([^"]*\)".*/\1/' | grep -v '^\[' | sort -u)
+  mac_ops_log_debug "Running apps: ${#_MAC_OPS_RUNNING_BUNDLES[@]} bundles protected"
+
   # Stage 2: Search for orphan data in each scan target path
   local total_cleaned=0
   for scan_dir in "${MAC_OPS_ORPHAN_APP_SCAN_DIRS[@]}"; do
@@ -56,8 +150,9 @@ mac_ops_orphan_app_cleanup() {
     fi
   done
 
-  # Cleanup global variable
+  # Cleanup global variables
   unset _MAC_OPS_INSTALLED_BUNDLES
+  unset _MAC_OPS_RUNNING_BUNDLES
 
   mac_ops_log_info "Orphan app data cleanup completed"
   return 0
@@ -65,57 +160,107 @@ mac_ops_orphan_app_cleanup() {
 
 # -----------------------------------------------------------------------------
 # Internal: Collect bundle IDs of installed apps into associative array
-# Includes both /Applications/*.app and ~/Applications/*.app
-# Usage: _mac_ops_collect_installed_bundles <associative_array_name>
+# Stage A: standard app directories (/Applications, ~/Applications, /System/Applications)
+# Stage B: mdfind (Spotlight) — JetBrains Toolbox, Whale, Setapp, mas, custom paths
+# Stage C: Homebrew Cask — /opt/homebrew/Caskroom (NOT indexed by Spotlight)
+# Stage D: LaunchDaemons/LaunchAgents — services like Korean banking security software
 # -----------------------------------------------------------------------------
 _mac_ops_collect_installed_bundles() {
-  local app_dirs=("/Applications" "${HOME}/Applications")
+  # Prevent ERR_EXIT from aborting the scan mid-way (PlistBuddy exits 1 even on success)
+  setopt LOCAL_OPTIONS NO_ERR_EXIT
+
   local info_plist=""
   local bundle_id=""
 
+  # Stage A: scan standard app directories (fast, covers most cases)
+  local app_dirs=("/Applications" "${HOME}/Applications" "/System/Applications")
+  local app_base app_path
   for app_base in "${app_dirs[@]}"; do
     [[ ! -d "${app_base}" ]] && continue
-
-    # shellcheck disable=SC1073,SC1036,SC1058,SC1072
-    for app_path in "${app_base}"/*.app(N); do
+    while IFS= read -r app_path; do
       [[ ! -d "${app_path}" ]] && continue
-
       info_plist="${app_path}/Contents/Info.plist"
-      if [[ ! -f "${info_plist}" ]]; then
-        mac_ops_log_debug "Info.plist not found: ${app_path}"
-        continue
-      fi
-
-      # Extract bundle ID
-      bundle_id=$(/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' "${info_plist}" 2>/dev/null)
+      [[ ! -f "${info_plist}" ]] && continue
+      bundle_id=$(/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' "${info_plist}" 2>/dev/null || true)
       if [[ -n "${bundle_id}" ]]; then
         _MAC_OPS_INSTALLED_BUNDLES[${bundle_id}]=1
-        mac_ops_log_debug "Bundle ID collected: ${bundle_id} (${app_path})"
+        mac_ops_log_debug "Bundle ID collected (path): ${bundle_id}"
       fi
-    done
+    done < <(find "${app_base}" -maxdepth 3 -name "*.app" -type d 2>/dev/null)
   done
+
+  # Stage B: mdfind — catches ALL Spotlight-indexed apps regardless of install location
+  # (JetBrains Toolbox, Whale, Setapp, mas, custom paths, etc.)
+  local mdfind_count=0
+  while IFS= read -r app_path; do
+    [[ ! -d "${app_path}" ]] && continue
+    info_plist="${app_path}/Contents/Info.plist"
+    [[ ! -f "${info_plist}" ]] && continue
+    bundle_id=$(/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' "${info_plist}" 2>/dev/null || true)
+    if [[ -n "${bundle_id}" && -z "${_MAC_OPS_INSTALLED_BUNDLES[${bundle_id}]+_}" ]]; then
+      _MAC_OPS_INSTALLED_BUNDLES[${bundle_id}]=1
+      mdfind_count=$(( mdfind_count + 1 ))
+      mac_ops_log_debug "Bundle ID collected (mdfind): ${bundle_id}"
+    fi
+  done < <(mdfind "kMDItemContentTypeTree == 'com.apple.application-bundle'" 2>/dev/null)
+  mac_ops_log_debug "mdfind added ${mdfind_count} additional bundle IDs"
+
+  # Stage C: Homebrew Cask — apps installed via brew are NOT indexed by Spotlight
+  # Covers: Arc, Warp, TablePlus, Proxyman, Raycast installed via brew cask, etc.
+  local brew_cask_count=0
+  local cask_base
+  for cask_base in "/opt/homebrew/Caskroom" "/usr/local/Caskroom"; do
+    [[ ! -d "${cask_base}" ]] && continue
+    while IFS= read -r app_path; do
+      [[ ! -d "${app_path}" ]] && continue
+      info_plist="${app_path}/Contents/Info.plist"
+      [[ ! -f "${info_plist}" ]] && continue
+      bundle_id=$(/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' "${info_plist}" 2>/dev/null || true)
+      if [[ -n "${bundle_id}" && -z "${_MAC_OPS_INSTALLED_BUNDLES[${bundle_id}]+_}" ]]; then
+        _MAC_OPS_INSTALLED_BUNDLES[${bundle_id}]=1
+        brew_cask_count=$(( brew_cask_count + 1 ))
+        mac_ops_log_debug "Bundle ID collected (brew-cask): ${bundle_id}"
+      fi
+    done < <(find "${cask_base}" -maxdepth 4 -name "*.app" -type d 2>/dev/null)
+  done
+  mac_ops_log_debug "Homebrew Cask added ${brew_cask_count} additional bundle IDs"
+
+  # Stage D: LaunchDaemons/LaunchAgents — system services not packaged as .app bundles
+  # Covers: Korean banking security (AhnLab V3, TouchEN nxKey, INISAFE CrossWeb EX, etc.)
+  local launch_count=0
+  local launch_dir plist_path launch_label
+  for launch_dir in \
+    "/Library/LaunchDaemons" \
+    "/Library/LaunchAgents" \
+    "${HOME}/Library/LaunchAgents"; do
+    [[ ! -d "${launch_dir}" ]] && continue
+    while IFS= read -r plist_path; do
+      launch_label=$(/usr/libexec/PlistBuddy -c 'Print Label' "${plist_path}" 2>/dev/null || true)
+      if [[ -n "${launch_label}" && -z "${_MAC_OPS_INSTALLED_BUNDLES[${launch_label}]+_}" ]]; then
+        _MAC_OPS_INSTALLED_BUNDLES[${launch_label}]=1
+        launch_count=$(( launch_count + 1 ))
+        mac_ops_log_debug "Bundle ID collected (launchd): ${launch_label}"
+      fi
+    done < <(find "${launch_dir}" -maxdepth 1 -name "*.plist" -type f 2>/dev/null)
+  done
+  mac_ops_log_debug "LaunchDaemons/Agents added ${launch_count} additional bundle IDs"
 }
 
 # -----------------------------------------------------------------------------
 # Internal: Search and cleanup orphan bundle ID entries in directory
 # Process directories whose name matches bundle ID pattern (com.xxx.xxx) but not in installed list
-# Usage: _mac_ops_scan_directory <scan_path> <installed_bundles_array_name>
+# Usage: _mac_ops_scan_directory <scan_path>
 # -----------------------------------------------------------------------------
 _mac_ops_scan_directory() {
   local scan_dir="${1}"
   local now_epoch
   local grace_seconds=$((MAC_OPS_ORPHAN_APP_GRACE_DAYS * 86400))
   local count=0
-  local item_name
-  local mtime
-  local age_seconds
-  local item_size
+  local item item_name mtime age_seconds item_size
 
   now_epoch=$(date +%s)
 
   mac_ops_log_info "Orphan data scan: ${scan_dir}"
-
-  count=0
 
   # Iterate only 1st level subitems (bundle ID directories)
   for item in "${scan_dir}"/*(N); do
@@ -132,13 +277,49 @@ _mac_ops_scan_directory() {
       continue
     fi
 
+    # Exclude macOS system group container patterns
+    if [[ "${item_name}" == systemgroup.* || "${item_name}" == group.* ]]; then
+      continue
+    fi
+
     # Don't process Group Containers subdirectories (can be shared by multiple apps)
     if [[ "${scan_dir}" == *"Group Containers"* ]]; then
       continue
     fi
 
-    # Skip if in installed apps list
-    if [[ -n "${_MAC_OPS_INSTALLED_BUNDLES[${item_name}]+_}" ]]; then
+    # Safety safelist check (second line of defense)
+    if _mac_ops_is_safelisted "${item_name}"; then
+      mac_ops_log_debug "Safelist protected: ${item_name}"
+      continue
+    fi
+
+    # User ignore rules: bundle ID pattern
+    if mac_ops_ignore_check_bundle "${item_name}"; then
+      mac_ops_log_debug "User ignore (bundle): ${item_name}"
+      continue
+    fi
+
+    # User ignore rules: path pattern
+    if mac_ops_ignore_check_path "${item}"; then
+      mac_ops_log_debug "User ignore (path): ${item}"
+      continue
+    fi
+
+    # Skip if in installed apps list (exact or prefix match — protects helper bundle IDs
+    # like com.google.Chrome.helper when com.google.Chrome is installed)
+    local _orphan_match=false
+    local _inst_id
+    for _inst_id in "${(@k)_MAC_OPS_INSTALLED_BUNDLES}"; do
+      if [[ "${item_name}" == "${_inst_id}" || "${item_name}" == "${_inst_id}."* ]]; then
+        _orphan_match=true
+        break
+      fi
+    done
+    [[ "${_orphan_match}" == "true" ]] && continue
+
+    # Skip if app is currently running
+    if [[ -n "${_MAC_OPS_RUNNING_BUNDLES[${item_name}]+_}" ]]; then
+      mac_ops_log_debug "Running app data protected: ${item_name}"
       continue
     fi
 
@@ -182,23 +363,18 @@ _mac_ops_scan_directory() {
 # -----------------------------------------------------------------------------
 # Internal: Search and cleanup orphan plist files in ~/Library/Preferences
 # Extract bundle ID from *.plist filename and match
-# Usage: _mac_ops_scan_preferences <Preferences_path> <installed_bundles_array_name>
+# Usage: _mac_ops_scan_preferences <Preferences_path>
 # -----------------------------------------------------------------------------
 _mac_ops_scan_preferences() {
   local pref_dir="${1}"
   local now_epoch
   local grace_seconds=$((MAC_OPS_ORPHAN_APP_GRACE_DAYS * 86400))
   local count=0
-  local file_name
-  local mtime
-  local age_seconds
-  local file_size
+  local plist_file file_name mtime age_seconds file_size
 
   now_epoch=$(date +%s)
 
   mac_ops_log_info "Orphan Preferences scan: ${pref_dir}"
-
-  count=0
 
   for plist_file in "${pref_dir}"/*.plist(N); do
     [[ ! -f "${plist_file}" ]] && continue
@@ -216,8 +392,37 @@ _mac_ops_scan_preferences() {
       continue
     fi
 
-    # Skip if in installed apps list
-    if [[ -n "${_MAC_OPS_INSTALLED_BUNDLES[${file_name}]+_}" ]]; then
+    # Exclude macOS system group container patterns
+    if [[ "${file_name}" == systemgroup.* || "${file_name}" == group.* ]]; then
+      continue
+    fi
+
+    # Safety safelist check (second line of defense)
+    if _mac_ops_is_safelisted "${file_name}"; then
+      mac_ops_log_debug "Safelist protected (pref): ${file_name}"
+      continue
+    fi
+
+    # User ignore rules: bundle ID pattern
+    if mac_ops_ignore_check_bundle "${file_name}"; then
+      mac_ops_log_debug "User ignore (bundle/pref): ${file_name}"
+      continue
+    fi
+
+    # Skip if in installed apps list (exact or prefix match for helper bundle IDs)
+    local _pref_match=false
+    local _pref_inst_id
+    for _pref_inst_id in "${(@k)_MAC_OPS_INSTALLED_BUNDLES}"; do
+      if [[ "${file_name}" == "${_pref_inst_id}" || "${file_name}" == "${_pref_inst_id}."* ]]; then
+        _pref_match=true
+        break
+      fi
+    done
+    [[ "${_pref_match}" == "true" ]] && continue
+
+    # Skip if app is currently running
+    if [[ -n "${_MAC_OPS_RUNNING_BUNDLES[${file_name}]+_}" ]]; then
+      mac_ops_log_debug "Running app preference protected: ${file_name}"
       continue
     fi
 

--- a/lib/modules/orphan-killer.zsh
+++ b/lib/modules/orphan-killer.zsh
@@ -99,6 +99,12 @@ mac_ops_orphan_killer() {
       continue
     fi
 
+    # User ignore rules: process name pattern
+    if mac_ops_ignore_check_process "${proc_name}"; then
+      mac_ops_log_debug "User ignore (process): ${proc_name} (PID: ${pid})"
+      continue
+    fi
+
     # Check if registered in launchctl
     # Skip if process name is included in service label
     is_registered=false

--- a/lib/modules/zombie-killer.zsh
+++ b/lib/modules/zombie-killer.zsh
@@ -61,6 +61,12 @@ mac_ops_zombie_killer() {
       continue
     fi
 
+    # User ignore rules: process name pattern
+    if mac_ops_ignore_check_process "${parent_name}"; then
+      mac_ops_log_debug "User ignore (process): ${parent_name} (PID: ${ppid})"
+      continue
+    fi
+
     mac_ops_log_info "Processing zombie PID ${zombie_pid} (parent: ${parent_name}, PPID: ${ppid})"
 
     # DRY_RUN mode


### PR DESCRIPTION
## Summary

- Add `~/.mac-ops/ignore` — user-defined exclusion rules with `[bundle]`, `[process]`, `[path]` sections and glob pattern support
- Add `lib/core/ignore.zsh` parser with `mac_ops_ignore_load()` and check functions
- Integrate ignore checks into `orphan-app-cleanup`, `zombie-killer`, `orphan-killer`
- Add `monitor` module: CPU/memory stats, 7-day history, sparkline/table CLI, top-N, kill by threshold
- Add Homebrew Cask (Stage C) and LaunchDaemons/Agents (Stage D) scanning in orphan-app detection
- Add `systemgroup.*`/`group.*` exclusions and `jetbrains.` bare prefix to safelist
- Extend safelist: Korean banking security (`com.ahnlab.`, `kr.co.*`, etc.), Chromium, Cursor, Zed, Charles Proxy
- Consolidate duplicate safelist into `_MAC_OPS_BUNDLE_SAFELIST` array with `_mac_ops_is_safelisted()` helper
- Disable `browser-cleanup` and `dev-cleanup` by default (`config/default.plist`)
- Add 30-day age filtering and `modules-*` protection for gradle in `dev-cleanup`
- Add `config/ignore.example` template

## Test plan

- [ ] Run `zsh -n` on all changed files — no syntax errors
- [ ] Run `mac-ops run --dry-run` and verify no installed app data is flagged
- [ ] Create `~/.mac-ops/ignore` with bundle/process/path entries and verify they are skipped
- [ ] Verify Homebrew Cask apps are detected (Stage C log output)
- [ ] Verify `monitor show` renders sparkline + table without errors
- [ ] Verify `dev-cleanup` skips `modules-*` gradle directories

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)