### PR TITLE
(#34) fix: code review — safety, race conditions, consistency improvements

### DIFF
--- a/bin/mac-ops
+++ b/bin/mac-ops
@@ -213,8 +213,8 @@ _mac_ops_cmd_run() {
     mac_ops_orphan_killer || true
   fi
 
-  # Cleanup statistics temporary directory
-  rm -rf "${stats_dir}" 2>/dev/null
+  # Cleanup statistics temporary directory (guard: must match expected path pattern)
+  [[ -n "${stats_dir}" && "${stats_dir}" == *"/stats_"* ]] && rm -rf "${stats_dir}" 2>/dev/null
 
   # 9. Delete expired files (72 hour threshold)
   mac_ops_trash_expire || true

--- a/lib/core/disk.zsh
+++ b/lib/core/disk.zsh
@@ -52,8 +52,7 @@ mac_ops_check_disk_space() {
   fi
 
   local available_bytes
-  available_bytes=$(mac_ops_get_disk_available)
-  if [[ $? -ne 0 ]]; then
+  if ! available_bytes=$(mac_ops_get_disk_available); then
     return 1
   fi
 
@@ -99,8 +98,7 @@ mac_ops_get_dir_size() {
 # -----------------------------------------------------------------------------
 mac_ops_emergency_purge() {
   local usage
-  usage=$(mac_ops_get_disk_usage)
-  if [[ $? -ne 0 ]]; then
+  if ! usage=$(mac_ops_get_disk_usage); then
     return 1
   fi
 

--- a/lib/core/lock.zsh
+++ b/lib/core/lock.zsh
@@ -31,10 +31,10 @@ mac_ops_acquire_lock() {
     fi
   fi
 
-  # Create new lock file (record current PID)
-  print -- "$$" > "${MAC_OPS_LOCK_FILE}" 2>/dev/null
-  if [[ $? -ne 0 ]]; then
-    mac_ops_log_error "Failed to create lock file: ${MAC_OPS_LOCK_FILE}"
+  # Atomic lock creation using noclobber (prevents TOCTOU race condition)
+  # If another process created the file between the check above and here, this will fail safely
+  if ! ( set -o noclobber; print -- "$$" > "${MAC_OPS_LOCK_FILE}" ) 2>/dev/null; then
+    mac_ops_log_error "Failed to create lock file (another process may have started): ${MAC_OPS_LOCK_FILE}"
     return 1
   fi
 

--- a/lib/core/trash.zsh
+++ b/lib/core/trash.zsh
@@ -16,9 +16,45 @@ typeset -gA _MAC_OPS_IDX_SIZE
 typeset -gA _MAC_OPS_IDX_EXPIRE
 typeset -ga _MAC_OPS_IDX_KEYS
 
+# Index mutex lock directory (mkdir is atomic — safe for parallel subshells)
+MAC_OPS_INDEX_LOCK_DIR="${MAC_OPS_TRASH_DIR}/.index.lock"
+
 # =============================================================================
 # JSON index helper functions
 # =============================================================================
+
+# -----------------------------------------------------------------------------
+# Acquire a mutex lock on the JSON index file (spin-wait, max ~3 seconds)
+# Usage: _mac_ops_index_lock
+# -----------------------------------------------------------------------------
+_mac_ops_index_lock() {
+  local retries=0
+  while ! mkdir "${MAC_OPS_INDEX_LOCK_DIR}" 2>/dev/null; do
+    retries=$((retries + 1))
+    if [[ ${retries} -gt 30 ]]; then
+      # Stale lock guard: if the lock directory is older than 60s, force-remove it
+      local lock_mtime
+      lock_mtime=$(stat -f%m "${MAC_OPS_INDEX_LOCK_DIR}" 2>/dev/null)
+      if [[ -n "${lock_mtime}" && $(( $(date +%s) - lock_mtime )) -gt 60 ]]; then
+        rmdir "${MAC_OPS_INDEX_LOCK_DIR}" 2>/dev/null || true
+        mac_ops_log_warn "Removed stale index lock (held > 60s)"
+        continue
+      fi
+      mac_ops_log_warn "Index lock timeout — proceeding without lock"
+      return 1
+    fi
+    sleep 0.1
+  done
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# Release the mutex lock on the JSON index file
+# Usage: _mac_ops_index_unlock
+# -----------------------------------------------------------------------------
+_mac_ops_index_unlock() {
+  rmdir "${MAC_OPS_INDEX_LOCK_DIR}" 2>/dev/null || true
+}
 
 # -----------------------------------------------------------------------------
 # Escape a string for safe JSON embedding
@@ -206,6 +242,9 @@ mac_ops_index_add() {
   local size_bytes="${7}"
   local expire_after="${8}"
 
+  # Acquire mutex to prevent race condition during parallel module execution
+  _mac_ops_index_lock
+
   mac_ops_index_read
 
   _MAC_OPS_IDX_KEYS+=("${key}")
@@ -218,6 +257,8 @@ mac_ops_index_add() {
   _MAC_OPS_IDX_EXPIRE[${key}]="${expire_after}"
 
   mac_ops_index_write
+
+  _mac_ops_index_unlock
 }
 
 # -----------------------------------------------------------------------------
@@ -514,8 +555,8 @@ mac_ops_trash_expire() {
       trash_path="${_MAC_OPS_IDX_TRASH[${key}]}"
       size_bytes="${_MAC_OPS_IDX_SIZE[${key}]:-0}"
 
-      # Permanently delete trash file
-      if [[ -n "${trash_path}" && -e "${trash_path}" ]]; then
+      # Permanently delete trash file (guard: must be inside MAC_OPS_TRASH_DIR)
+      if [[ -n "${trash_path}" && "${trash_path}" == "${MAC_OPS_TRASH_DIR}/"* && -e "${trash_path}" ]]; then
         rm -rf "${trash_path}" 2>/dev/null
         freed_bytes=$((freed_bytes + size_bytes))
       fi

--- a/lib/modules/analyze.zsh
+++ b/lib/modules/analyze.zsh
@@ -31,11 +31,11 @@ mac_ops_analyze() {
   current_user="${USER}"
 
   mac_ops_log_info "Starting disk space analysis..."
-  echo ""
-  echo "$(mac_ops_color_bold '==========================================')"
-  echo "$(mac_ops_color_bold '        mac-ops Disk Space Analysis')"
-  echo "$(mac_ops_color_bold '==========================================')"
-  echo ""
+  print
+  print -- "$(mac_ops_color_bold '==========================================')"
+  print -- "$(mac_ops_color_bold '        mac-ops Disk Space Analysis')"
+  print -- "$(mac_ops_color_bold '==========================================')"
+  print
 
   # 1. ~/Library/Caches
   category_name="System Cache"
@@ -43,7 +43,7 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     cache_total=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${cache_total}")
-    echo "$(mac_ops_color_blue '●') ${category_name} (Total): ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name} (Total): ${formatted_size}"
 
     # Calculate size excluding com.apple.*
     cache_non_apple=0
@@ -65,11 +65,11 @@ mac_ops_analyze() {
     done
 
     formatted_size=$(mac_ops_format_bytes "${cache_non_apple}")
-    echo "  $(mac_ops_color_green '└─') Excluding Apple: ${formatted_size}"
+    print -- "  $(mac_ops_color_green '└─') Excluding Apple: ${formatted_size}"
     total_bytes=$((total_bytes + cache_non_apple))
     mac_ops_log_debug "System cache: ${formatted_size} (Excluding Apple)"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
     mac_ops_log_debug "System cache directory not found"
   fi
 
@@ -79,11 +79,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "System logs: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # 3. ~/Library/Developer/Xcode/DerivedData
@@ -92,11 +92,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "Xcode DerivedData: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: Not installed"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: Not installed"
   fi
 
   # 4. Homebrew cache
@@ -106,14 +106,14 @@ mac_ops_analyze() {
     if [[ -n "${target_path}" && -d "${target_path}" ]]; then
       size_bytes=$(mac_ops_get_dir_size "${target_path}")
       formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-      echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+      print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
       total_bytes=$((total_bytes + size_bytes))
       mac_ops_log_debug "Homebrew cache: ${formatted_size}"
     else
-      echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+      print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
     fi
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: Not installed"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: Not installed"
   fi
 
   # 5. npm cache
@@ -122,11 +122,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "npm cache: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # 6. yarn cache
@@ -135,11 +135,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "Yarn cache: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # 7. pnpm cache
@@ -148,11 +148,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "pnpm Store: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # 8. pip cache
@@ -161,11 +161,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "pip cache: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # 9. Gradle cache
@@ -174,11 +174,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "Gradle cache: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # 10. /tmp (current user files only)
@@ -192,11 +192,11 @@ mac_ops_analyze() {
       user_tmp_size=$((user_tmp_size + item_size))
     done < <(find "${target_path}" -maxdepth 1 -user "${current_user}" 2>/dev/null)
     formatted_size=$(mac_ops_format_bytes "${user_tmp_size}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + user_tmp_size))
     mac_ops_log_debug "Temporary files: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # 11. /private/var/folders (current user files only)
@@ -209,15 +209,15 @@ mac_ops_analyze() {
       user_var_size=$((user_var_size + item_size))
     done < <(find "${target_path}" -maxdepth 3 -type d -user "${current_user}" 2>/dev/null)
     formatted_size=$(mac_ops_format_bytes "${user_var_size}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + user_var_size))
     mac_ops_log_debug "System temp folders: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # 12. Browser cache
-  echo "$(mac_ops_color_blue '●') Browser Cache:"
+  print -- "$(mac_ops_color_blue '●') Browser Cache:"
 
   # Safari
   category_name="  Safari"
@@ -225,11 +225,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "  $(mac_ops_color_green '└─') Safari: ${formatted_size}"
+    print -- "  $(mac_ops_color_green '└─') Safari: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "Safari cache: ${formatted_size}"
   else
-    echo "  $(mac_ops_color_green '└─') Safari: N/A"
+    print -- "  $(mac_ops_color_green '└─') Safari: N/A"
   fi
 
   # Chrome
@@ -237,11 +237,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "  $(mac_ops_color_green '└─') Chrome: ${formatted_size}"
+    print -- "  $(mac_ops_color_green '└─') Chrome: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "Chrome cache: ${formatted_size}"
   else
-    echo "  $(mac_ops_color_green '└─') Chrome: Not installed"
+    print -- "  $(mac_ops_color_green '└─') Chrome: Not installed"
   fi
 
   # Firefox
@@ -249,11 +249,11 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "  $(mac_ops_color_green '└─') Firefox: ${formatted_size}"
+    print -- "  $(mac_ops_color_green '└─') Firefox: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "Firefox cache: ${formatted_size}"
   else
-    echo "  $(mac_ops_color_green '└─') Firefox: Not installed"
+    print -- "  $(mac_ops_color_green '└─') Firefox: Not installed"
   fi
 
   # 13. Docker
@@ -261,14 +261,14 @@ mac_ops_analyze() {
   if command -v docker &>/dev/null && docker info &>/dev/null; then
     docker_size=$(docker system df --format "{{.Size}}" 2>/dev/null | head -1)
     if [[ -n "${docker_size}" ]]; then
-      echo "$(mac_ops_color_blue '●') ${category_name}: ${docker_size}"
+      print -- "$(mac_ops_color_blue '●') ${category_name}: ${docker_size}"
       mac_ops_log_debug "Docker: ${docker_size}"
       # Docker size is not included in total_bytes (managed separately)
     else
-      echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+      print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
     fi
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: Not installed or not running"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: Not installed or not running"
   fi
 
   # 14. mac-ops trash
@@ -277,20 +277,20 @@ mac_ops_analyze() {
   if [[ -d "${target_path}" ]]; then
     size_bytes=$(mac_ops_get_dir_size "${target_path}")
     formatted_size=$(mac_ops_format_bytes "${size_bytes}")
-    echo "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: ${formatted_size}"
     total_bytes=$((total_bytes + size_bytes))
     mac_ops_log_debug "mac-ops trash: ${formatted_size}"
   else
-    echo "$(mac_ops_color_blue '●') ${category_name}: N/A"
+    print -- "$(mac_ops_color_blue '●') ${category_name}: N/A"
   fi
 
   # Total summary
-  echo ""
-  echo "$(mac_ops_color_bold '==========================================')"
+  print
+  print -- "$(mac_ops_color_bold '==========================================')"
   formatted_size=$(mac_ops_format_bytes "${total_bytes}")
-  echo "$(mac_ops_color_bold "Total Reclaimable Space: $(mac_ops_color_green "${formatted_size}")")"
-  echo "$(mac_ops_color_bold '==========================================')"
-  echo ""
+  print -- "$(mac_ops_color_bold "Total Reclaimable Space: $(mac_ops_color_green "${formatted_size}")")"
+  print -- "$(mac_ops_color_bold '==========================================')"
+  print
 
   mac_ops_log_info "Disk space analysis completed: Total ${formatted_size}"
 

--- a/lib/modules/browser-cleanup.zsh
+++ b/lib/modules/browser-cleanup.zsh
@@ -40,6 +40,11 @@ _mac_ops_browser_safari() {
     item_size=$(mac_ops_get_dir_size "${cache_item}")
     mac_ops_log_info "Cleaning Safari cache item: ${item_basename} ($(mac_ops_format_bytes ${item_size}))"
 
+    if mac_ops_ignore_check_path "${cache_item}"; then
+      mac_ops_log_debug "User ignore (path): ${cache_item}"
+      continue
+    fi
+
     if mac_ops_trash_move "${cache_item}" "browser-cache" "safari"; then
       MAC_OPS_CLEANED_COUNT=$((${MAC_OPS_CLEANED_COUNT:-0} + 1))
       MAC_OPS_CLEANED_BYTES=$((${MAC_OPS_CLEANED_BYTES:-0} + item_size))
@@ -94,7 +99,12 @@ _mac_ops_browser_chrome() {
       item_size=$(mac_ops_get_dir_size "${cache_item}")
       mac_ops_log_info "Cleaning Chrome cache item: $(basename ${cache_dir})/${item_basename} ($(mac_ops_format_bytes ${item_size}))"
 
-      if mac_ops_trash_move "${cache_item}" "browser-cache" "chrome"; then
+      if mac_ops_ignore_check_path "${cache_item}"; then
+      mac_ops_log_debug "User ignore (path): ${cache_item}"
+      continue
+    fi
+
+    if mac_ops_trash_move "${cache_item}" "browser-cache" "chrome"; then
         MAC_OPS_CLEANED_COUNT=$((${MAC_OPS_CLEANED_COUNT:-0} + 1))
         MAC_OPS_CLEANED_BYTES=$((${MAC_OPS_CLEANED_BYTES:-0} + item_size))
       fi
@@ -151,7 +161,12 @@ _mac_ops_browser_firefox() {
       item_size=$(mac_ops_get_dir_size "${cache_item}")
       mac_ops_log_info "Cleaning Firefox cache item: $(basename ${profile_dir})/${item_basename} ($(mac_ops_format_bytes ${item_size}))"
 
-      if mac_ops_trash_move "${cache_item}" "browser-cache" "firefox"; then
+      if mac_ops_ignore_check_path "${cache_item}"; then
+      mac_ops_log_debug "User ignore (path): ${cache_item}"
+      continue
+    fi
+
+    if mac_ops_trash_move "${cache_item}" "browser-cache" "firefox"; then
         MAC_OPS_CLEANED_COUNT=$((${MAC_OPS_CLEANED_COUNT:-0} + 1))
         MAC_OPS_CLEANED_BYTES=$((${MAC_OPS_CLEANED_BYTES:-0} + item_size))
       fi

--- a/lib/modules/cache-cleanup.zsh
+++ b/lib/modules/cache-cleanup.zsh
@@ -106,6 +106,11 @@ mac_ops_cache_cleanup() {
 
       mac_ops_log_info "Cache directory cleanup: ${bundle_name} (${file_count} files, $(mac_ops_format_bytes ${dir_size}))"
 
+      if mac_ops_ignore_check_path "${bundle_dir}"; then
+        mac_ops_log_debug "User ignore (path): ${bundle_dir}"
+        continue
+      fi
+
       if mac_ops_trash_move "${bundle_dir}" "cache-expired" "cache-cleanup"; then
         MAC_OPS_CLEANED_COUNT=$((${MAC_OPS_CLEANED_COUNT:-0} + file_count))
         MAC_OPS_CLEANED_BYTES=$((${MAC_OPS_CLEANED_BYTES:-0} + dir_size))
@@ -133,7 +138,7 @@ mac_ops_cache_cleanup() {
     age_seconds=$((now_epoch - mtime))
 
     if [[ ${age_seconds} -ge ${threshold_seconds} ]]; then
-      if mac_ops_is_path_safe "${cache_file}" && mac_ops_check_size_guard "${cache_file}"; then
+      if mac_ops_is_path_safe "${cache_file}" && mac_ops_check_size_guard "${cache_file}" && ! mac_ops_ignore_check_path "${cache_file}"; then
         file_size=$(mac_ops_get_dir_size "${cache_file}")
         if mac_ops_trash_move "${cache_file}" "cache-expired" "cache-cleanup"; then
           MAC_OPS_CLEANED_COUNT=$((${MAC_OPS_CLEANED_COUNT:-0} + 1))

--- a/lib/modules/dev-cleanup.zsh
+++ b/lib/modules/dev-cleanup.zsh
@@ -156,6 +156,10 @@ _mac_ops_dev_npm() {
       mac_ops_log_debug "Skipping recent npm cache: $(basename ${item})"
       continue
     fi
+    if mac_ops_ignore_check_path "${item}"; then
+      mac_ops_log_debug "User ignore (path): ${item}"
+      continue
+    fi
     _dev_sz=$(mac_ops_get_dir_size "${item}")
     if mac_ops_trash_move "${item}" "npm cache cleanup" "dev-cleanup"; then
       _dev_cleaned=$((_dev_cleaned + _dev_sz))
@@ -212,6 +216,10 @@ _mac_ops_dev_yarn() {
     _dev_mtime=$(stat -f%m "${item}" 2>/dev/null || echo 0)
     if [[ $((_dev_now - _dev_mtime)) -lt ${_dev_max_age_s} ]]; then
       mac_ops_log_debug "Skipping recent yarn cache: $(basename ${item})"
+      continue
+    fi
+    if mac_ops_ignore_check_path "${item}"; then
+      mac_ops_log_debug "User ignore (path): ${item}"
       continue
     fi
     _dev_sz=$(mac_ops_get_dir_size "${item}")
@@ -272,6 +280,10 @@ _mac_ops_dev_pnpm() {
       mac_ops_log_debug "Skipping recent pnpm store: $(basename ${item})"
       continue
     fi
+    if mac_ops_ignore_check_path "${item}"; then
+      mac_ops_log_debug "User ignore (path): ${item}"
+      continue
+    fi
     _dev_sz=$(mac_ops_get_dir_size "${item}")
     if mac_ops_trash_move "${item}" "pnpm store cleanup" "dev-cleanup"; then
       _dev_cleaned=$((_dev_cleaned + _dev_sz))
@@ -328,6 +340,10 @@ _mac_ops_dev_pip() {
     _dev_mtime=$(stat -f%m "${item}" 2>/dev/null || echo 0)
     if [[ $((_dev_now - _dev_mtime)) -lt ${_dev_max_age_s} ]]; then
       mac_ops_log_debug "Skipping recent pip cache: $(basename ${item})"
+      continue
+    fi
+    if mac_ops_ignore_check_path "${item}"; then
+      mac_ops_log_debug "User ignore (path): ${item}"
       continue
     fi
     _dev_sz=$(mac_ops_get_dir_size "${item}")
@@ -397,6 +413,10 @@ _mac_ops_dev_gradle() {
     _dev_mtime=$(stat -f%m "${item}" 2>/dev/null || echo 0)
     if [[ $((_dev_now - _dev_mtime)) -lt ${_dev_max_age_s} ]]; then
       mac_ops_log_debug "Skipping recent gradle cache: ${_dev_item_name}"
+      continue
+    fi
+    if mac_ops_ignore_check_path "${item}"; then
+      mac_ops_log_debug "User ignore (path): ${item}"
       continue
     fi
     _dev_sz=$(mac_ops_get_dir_size "${item}")

--- a/lib/modules/docker-cleanup.zsh
+++ b/lib/modules/docker-cleanup.zsh
@@ -173,24 +173,19 @@ _mac_ops_docker_parse_size() {
   local number
   local unit
 
-  if [[ "${size_str}" =~ ^([0-9.]+)([KMGT]?B)$ ]]; then
-    number="${BASH_REMATCH[1]}"
-    unit="${BASH_REMATCH[2]}"
+  if [[ "${size_str}" =~ '^([0-9.]+)([KMGT]?B)$' ]]; then
+    number="${match[1]}"
+    unit="${match[2]}"
   else
     # Return 0 on parsing failure
     echo "0"
     return 0
   fi
 
-  # Convert decimal to integer (1.2 -> 12, multiply by 10)
+  # Convert to integer bytes using awk for correct decimal handling (1.23GB, 0.5MB, etc.)
   local int_number
-  if [[ "${number}" == *.* ]]; then
-    # Remove decimal point and multiply by 10
-    int_number=$(echo "${number}" | sed 's/\.//' | sed 's/^0*//')
-    [[ -z "${int_number}" ]] && int_number=0
-  else
-    int_number=$((number * 10))
-  fi
+  int_number=$(awk "BEGIN{printf \"%d\", ${number} * 10}" 2>/dev/null)
+  [[ -z "${int_number}" ]] && int_number=0
 
   # Convert by unit
   local bytes=0

--- a/lib/modules/log-cleanup.zsh
+++ b/lib/modules/log-cleanup.zsh
@@ -109,6 +109,12 @@ _mac_ops_log_clean_dir() {
       continue
     fi
 
+    # User ignore rules: path pattern
+    if mac_ops_ignore_check_path "${file_path}"; then
+      mac_ops_log_debug "User ignore (path): ${file_path}"
+      continue
+    fi
+
     # Record file size
     file_size=$(mac_ops_get_dir_size "${file_path}")
 

--- a/lib/modules/monitor.zsh
+++ b/lib/modules/monitor.zsh
@@ -25,14 +25,16 @@ _mac_ops_monitor_mem() {
   local vm_out
   vm_out=$(vm_stat 2>/dev/null)
 
-  local wired active compressed
+  # Include speculative pages — consistent with snapshot.zsh formula
+  local wired active compressed speculative
   wired=$(awk '/Pages wired down/{gsub(/\./, "", $NF); print $NF+0}' <<< "$vm_out")
   active=$(awk '/Pages active/{gsub(/\./, "", $NF); print $NF+0}' <<< "$vm_out")
   compressed=$(awk '/Pages occupied by compressor/{gsub(/\./, "", $NF); print $NF+0}' <<< "$vm_out")
+  speculative=$(awk '/Pages speculative/{gsub(/\./, "", $NF); print $NF+0}' <<< "$vm_out")
 
   local total used pct
   total=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
-  used=$(( (wired + active + compressed) * page_size ))
+  used=$(( (wired + active + compressed + speculative) * page_size ))
   pct=$(awk "BEGIN{printf \"%.1f\", ($total>0)?($used/$total*100):0}")
 
   echo "$used $total $pct"

--- a/lib/modules/tmp-cleanup.zsh
+++ b/lib/modules/tmp-cleanup.zsh
@@ -74,6 +74,12 @@ _mac_ops_tmp_clean_path() {
       continue
     fi
 
+    # User ignore rules: path pattern
+    if mac_ops_ignore_check_path "${file_path}"; then
+      mac_ops_log_debug "User ignore (path): ${file_path}"
+      continue
+    fi
+
     # Record file size
     file_size=$(mac_ops_get_dir_size "${file_path}")
 
@@ -129,6 +135,12 @@ _mac_ops_tmp_clean_var_folders() {
 
     # Size guard check
     if ! mac_ops_check_size_guard "${file_path}"; then
+      continue
+    fi
+
+    # User ignore rules: path pattern
+    if mac_ops_ignore_check_path "${file_path}"; then
+      mac_ops_log_debug "User ignore (path): ${file_path}"
       continue
     fi
 

--- a/lib/utils/notify.zsh
+++ b/lib/utils/notify.zsh
@@ -13,8 +13,14 @@ mac_ops_notify() {
     return 0
   fi
 
+  # Escape special characters before embedding in AppleScript string
+  local safe_title="${title//\\/\\\\}"
+  safe_title="${safe_title//\"/\\\"}"
+  local safe_message="${message//\\/\\\\}"
+  safe_message="${safe_message//\"/\\\"}"
+
   # Ignore errors even if osascript fails (e.g., headless environment)
-  osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+  osascript -e "display notification \"${safe_message}\" with title \"${safe_title}\"" 2>/dev/null || true
   return 0
 }
 


### PR DESCRIPTION
## Summary

Full codebase code review fixes addressing CRITICAL race conditions, security issues, and consistency gaps.

### CRITICAL
- **trash.zsh**: `_mac_ops_index_lock/unlock` — `mkdir`-based mutex around `mac_ops_index_add` prevents index corruption during parallel module execution
- **trash.zsh**: `mac_ops_trash_expire` path guard — `trash_path` must be inside `MAC_OPS_TRASH_DIR` before `rm -rf`
- **docker-cleanup.zsh**: Replace zsh-incompatible `BASH_REMATCH[1/2]` with `match[1/2]`; fix decimal size parsing with awk

### HIGH
- **notify.zsh**: Escape `"` and `\` before embedding in AppleScript (prevents command injection via filenames)
- **lock.zsh**: Atomic lock creation via `set -o noclobber` subshell (eliminates TOCTOU window)
- **cache/tmp/log/browser/dev-cleanup**: Add `mac_ops_ignore_check_path` before each `mac_ops_trash_move` — user `[path]` ignore rules were silently ignored

### MEDIUM / LOW
- **disk.zsh**: Fix `cmd; if [[ $? ]]` anti-pattern → `if ! cmd=...` pattern
- **bin/mac-ops**: Add path guard for `stats_dir` before `rm -rf`
- **monitor.zsh**: Add `speculative` pages to memory formula (consistent with `snapshot.zsh`)
- **analyze.zsh**: Replace all `echo` with `print --` for zsh consistency

## Test plan

- [ ] `zsh -n` on all 13 changed files — all pass
- [ ] Parallel run: `mac-ops run --dry-run` completes without index file errors
- [ ] Create two rapid `mac-ops` instances and verify only one acquires lock
- [ ] Add `[path] ~/Library/Caches/SomeApp` to ignore file — verify not cleaned
- [ ] Docker cleanup: verify size bytes parsed correctly for decimal values (e.g. `1.23GB`)
- [ ] Notification: verify filename with `"` characters doesn't break osascript

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)