### PR TITLE
(#36) feat: monitor launchd setup/unsetup and README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ git clone https://github.com/seunggabi/mac-ops.git && cd mac-ops && chmod +x bin
 First run:
 
 ```bash
-bin/mac-ops run --dry-run   # Preview what will be cleaned
-bin/mac-ops analyze          # Disk space report
-bin/mac-ops run              # Execute cleanup
+mac-ops run --dry-run   # Preview what will be cleaned
+mac-ops analyze          # Disk space report
+mac-ops run              # Execute cleanup
 ```
 
 ## Why mac-ops
@@ -45,14 +45,14 @@ bin/mac-ops run              # Execute cleanup
 Every file mac-ops cleans is moved to `~/.mac-ops/.trash/` instead of being permanently deleted. You have **72 hours** to restore anything with a single command. No other CLI cleanup tool offers this level of protection.
 
 ```bash
-bin/mac-ops restore ~/Library/Caches/com.important.app   # Undo a mistake instantly
+mac-ops restore ~/Library/Caches/com.important.app   # Undo a mistake instantly
 ```
 
 ### Zero Dependencies
 
 Pure zsh. No Python, no Ruby, no Node.js. Only macOS built-in tools (`zsh`, `plutil`, `launchd`). Install and run anywhere with no setup overhead.
 
-### 5-Layer Safety System
+### 6-Layer Safety System
 
 | Layer | Protection |
 |-------|-----------|
@@ -60,6 +60,7 @@ Pure zsh. No Python, no Ruby, no Node.js. Only macOS built-in tools (`zsh`, `plu
 | Blacklist | System paths, keychains, and user documents are never touched |
 | Size Guard | Files over 2 GB are automatically skipped |
 | Process Protection | Critical system processes (`kernel_task`, `WindowServer`, `launchd`, ...) are never killed |
+| User Ignore Rules | `~/.mac-ops/ignore` lets you exempt specific apps, processes, or paths |
 | Lock | Prevents concurrent execution to avoid race conditions |
 
 ### 10 Cleanup Modules
@@ -86,7 +87,7 @@ File-based modules run concurrently to minimize cleanup time. Process modules ex
 Native `launchd` integration runs cleanup every hour, catching up on missed runs after sleep/wake. One command to install:
 
 ```bash
-bin/mac-ops install
+mac-ops install
 ```
 
 ## Comparison
@@ -108,51 +109,88 @@ bin/mac-ops install
 
 ```bash
 # Preview (dry-run) - Check cleanup targets without actual deletion
-bin/mac-ops run --dry-run
+mac-ops run --dry-run
 
 # Execute cleanup
-bin/mac-ops run
+mac-ops run
 
 # Run specific module only
-bin/mac-ops run --module=cache
-bin/mac-ops run --module=browser
-bin/mac-ops run --module=docker
+mac-ops run --module=cache
+mac-ops run --module=browser
+mac-ops run --module=docker
 
 # Disk space analysis report
-bin/mac-ops analyze
+mac-ops analyze
 
 # Verbose logging
-bin/mac-ops run --verbose
+mac-ops run --verbose
+```
+
+### Monitor
+
+```bash
+# Memory & CPU dashboard with 7-day history
+mac-ops monitor
+
+# Hourly sparkline view (24h breakdown per day)
+mac-ops monitor --hours
+
+# Show top N processes by memory usage (default: 10)
+mac-ops monitor top 20
+
+# Kill processes using more than M MB (default: 500)
+mac-ops monitor kill 1000
+
+# Record a memory/CPU snapshot manually
+mac-ops monitor collect
+```
+
+History is stored as CSV in `~/.mac-ops/monitor/YYYY-MM-DD.csv` and auto-purged after 7 days.
+
+To collect snapshots automatically, add to crontab (`crontab -e`):
+
+```cron
+# Collect every 5 minutes
+*/5 * * * * mac-ops monitor collect >> ~/.mac-ops/.logs/monitor.log 2>&1
+```
+
+Or via launchd (recommended on macOS):
+
+```bash
+mac-ops monitor setup    # Install launchd agent (every 5 min)
+mac-ops monitor unsetup  # Uninstall
 ```
 
 ### Trash Management
 
 ```bash
 # List trash contents
-bin/mac-ops list-trash
+mac-ops list-trash
 
 # Restore accidentally deleted files
-bin/mac-ops restore ~/Library/Caches/com.important.app
+mac-ops restore ~/Library/Caches/com.important.app
 
 # Immediately purge expired items
-bin/mac-ops purge
+mac-ops purge
 
 # Check current status (trash, disk usage, launchd status)
-bin/mac-ops status
+mac-ops status
 ```
 
 ### Miscellaneous
 
 ```bash
 # Check current configuration
-bin/mac-ops config
+mac-ops config
 
 # Check version
-bin/mac-ops version
+mac-ops version
 
 # Show help
-bin/mac-ops help
+mac-ops help
 ```
+
+> Available modules: `cache`, `tmp`, `log`, `zombie`, `orphan`, `orphan-app`, `brew`, `dev`, `docker`, `browser`
 
 ## Configuration
 
@@ -166,11 +204,38 @@ export MAC_OPS_CACHE_MAX_AGE_DAYS=30   # Delete caches older than N days (defaul
 export MAC_OPS_CACHE_RECENT_DAYS=7     # Protect caches used within N days (default: 7)
 
 # Example: More aggressive cache cleanup
-MAC_OPS_CACHE_MAX_AGE_DAYS=30 bin/mac-ops run --module=cache
+MAC_OPS_CACHE_MAX_AGE_DAYS=30 mac-ops run --module=cache
 
 # Example: Protect only very recent caches
-MAC_OPS_CACHE_RECENT_DAYS=1 bin/mac-ops run --module=cache
+MAC_OPS_CACHE_RECENT_DAYS=1 mac-ops run --module=cache
 ```
+
+### Ignore File
+
+Create `~/.mac-ops/ignore` to permanently exempt specific apps, processes, or paths from cleanup:
+
+```ini
+# ~/.mac-ops/ignore
+# Lines starting with # are comments. Empty lines are ignored.
+# Glob patterns are supported (*, **, ?).
+
+[bundle]
+# Bundle ID patterns — skipped by orphan-app-cleanup
+# com.mycompany.*
+# com.example.DevBuild
+
+[process]
+# Process name patterns — skipped by zombie-killer and orphan-killer
+# my-custom-daemon
+# MyVendorHelper*
+
+[path]
+# Path patterns — skipped by all file-based cleanup modules
+# ~/work/.cache
+# ~/projects/my-project
+```
+
+Copy `config/ignore.example` as a starting template.
 
 ### Cache Protection Policy
 
@@ -179,8 +244,8 @@ The cache cleanup module now includes **smart protection** to prevent accidental
 1. ✅ **Apple system caches** (`com.apple.*`) - Always protected
 2. ✅ **Installed applications** - Caches from apps in `/Applications` are protected
 3. ✅ **Running applications** - Caches from currently running apps are protected
-4. ✅ **Recently used caches** - Caches accessed within `MAC_OPS_CACHE_RECENT_DAYS` (default: 3 days) are protected
-5. ✅ **Orphan caches only** - Only caches from uninstalled/inactive apps older than `MAC_OPS_CACHE_MAX_AGE_DAYS` (default: 7 days) are cleaned
+4. ✅ **Recently used caches** - Caches accessed within `MAC_OPS_CACHE_RECENT_DAYS` (default: 7 days) are protected
+5. ✅ **Orphan caches only** - Only caches from uninstalled/inactive apps older than `MAC_OPS_CACHE_MAX_AGE_DAYS` (default: 30 days) are cleaned
 
 This ensures your login sessions, preferences, and active app data are never touched during cleanup.
 
@@ -192,12 +257,12 @@ macOS native scheduler runs automatically every hour. Catches up on missed tasks
 
 ```bash
 # Install
-bin/mac-ops install
+mac-ops install
 ```
 
 ```bash
 # Uninstall
-bin/mac-ops uninstall
+mac-ops uninstall
 ```
 
 ### Method 2: crontab
@@ -210,10 +275,10 @@ Add the following content:
 
 ```cron
 # Run mac-ops every hour
-0 * * * * /path/to/mac-ops/bin/mac-ops run --scheduled 2>&1 >> ~/.mac-ops/.logs/cron.log
+0 * * * * mac-ops run --scheduled 2>&1 >> ~/.mac-ops/.logs/cron.log
 
 # Or run daily at 3 AM
-0 3 * * * /path/to/mac-ops/bin/mac-ops run --scheduled 2>&1 >> ~/.mac-ops/.logs/cron.log
+0 3 * * * mac-ops run --scheduled 2>&1 >> ~/.mac-ops/.logs/cron.log
 ```
 
 > Replace `/path/to/mac-ops` with your actual installation path.
@@ -238,9 +303,9 @@ sudo rm -rf ~/.mac-ops/.trash
 | `sudo rm -rf ~/.mac-ops/.trash` | **CRITICAL** | Permanently deletes all recoverable files, bypassing the 72-hour safety net |
 
 **Before running these commands:**
-1. Run `bin/mac-ops list-trash` to check what is in the trash
-2. Run `bin/mac-ops run --dry-run` to preview cleanup targets
-3. Restore any important files with `bin/mac-ops restore <path>`
+1. Run `mac-ops list-trash` to check what is in the trash
+2. Run `mac-ops run --dry-run` to preview cleanup targets
+3. Restore any important files with `mac-ops restore <path>`
 
 ### Full Disk Access Permission Required
 
@@ -257,7 +322,7 @@ Add Terminal.app (or iTerm, Warp, etc. depending on your terminal). For launchd 
 When using for the first time, always check what files will be cleaned with `--dry-run`.
 
 ```bash
-bin/mac-ops run --dry-run
+mac-ops run --dry-run
 ```
 
 ### 72-hour Grace Period
@@ -272,14 +337,16 @@ bin/mac-ops run --dry-run
 |------|--------|
 | `/System/*`, `/bin/*`, `/sbin/*`, `/usr/*` | SIP protected |
 | `~/Library/Keychains/*` | Keychains (passwords, certificates) |
-| `~/Documents/*`, `~/Desktop/*` | User documents |
-| `/Library/LaunchDaemons/*` | System services |
+| `~/Library/Preferences/*` | User preferences |
+| `~/Documents/*`, `~/Desktop/*`, `~/Downloads/*` | User documents |
+| `/Library/LaunchDaemons/*`, `/Library/LaunchAgents/*` | System services |
 
 ### Processes Never Killed
 
 ```
 kernel_task, launchd, WindowServer, loginwindow,
-SystemUIServer, Finder, cfprefsd, mds, mds_stores
+SystemUIServer, Finder, Dock, cfprefsd, mds, mds_stores,
+coreaudiod, opendirectoryd
 ```
 
 ### Docker Module
@@ -302,7 +369,8 @@ mac-ops/
 │   │   ├── logger.zsh             # Logging
 │   │   ├── lock.zsh               # Prevent duplicate execution
 │   │   ├── safety.zsh             # Safety system
-│   │   └── disk.zsh               # Disk monitoring
+│   │   ├── disk.zsh               # Disk monitoring
+│   │   └── ignore.zsh             # User ignore rules (~/.mac-ops/ignore)
 │   ├── modules/                   # Cleanup modules
 │   │   ├── cache-cleanup.zsh
 │   │   ├── tmp-cleanup.zsh
@@ -314,7 +382,8 @@ mac-ops/
 │   │   ├── dev-cleanup.zsh
 │   │   ├── docker-cleanup.zsh
 │   │   ├── browser-cleanup.zsh
-│   │   └── analyze.zsh
+│   │   ├── analyze.zsh
+│   │   └── monitor.zsh
 │   └── utils/                     # Shared utilities
 │       ├── format.zsh
 │       ├── notify.zsh
@@ -322,6 +391,8 @@ mac-ops/
 │       ├── plist-helper.zsh
 │       └── snapshot.zsh
 ├── config/                        # Configuration files
+│   ├── default.plist              # Default module enable/disable settings
+│   └── ignore.example             # Example ignore file template
 ├── launchd/                       # launchd agents
 ├── scripts/                       # Utility scripts
 ├── demo/                          # Demo and example files

--- a/bin/mac-ops
+++ b/bin/mac-ops
@@ -79,9 +79,12 @@ Commands:
   run              Run cleanup (default command)
   analyze          Disk space analysis report
   monitor          Memory & CPU usage dashboard (7-day history)
+  monitor --hours  Show hourly sparkline view
   monitor top [N]  Show top N processes by memory (default: 10)
   monitor kill [M] Kill processes using more than M MB (default: 500)
   monitor collect  Record a snapshot (use for scheduled collection)
+  monitor setup    Install launchd agent (collect every 5 min)
+  monitor unsetup  Uninstall launchd agent
   status           Show trash status and disk usage
   restore <path>   Restore from trash to original location
   list-trash       List trash contents
@@ -398,6 +401,32 @@ _mac_ops_cmd_monitor() {
     collect)
       mac_ops_monitor_collect
       mac_ops_log_info "Monitor snapshot collected"
+      ;;
+    setup)
+      local plist_src="${MAC_OPS_ROOT}/launchd/com.mac-ops.monitor.plist"
+      local plist_dst="${HOME}/Library/LaunchAgents/com.mac-ops.monitor.plist"
+      local bin_path="${MAC_OPS_ROOT}/bin/mac-ops"
+      local home_path="${HOME}/.mac-ops"
+      if [[ ! -f "${plist_src}" ]]; then
+        mac_ops_log_error "plist template not found: ${plist_src}"
+        return 1
+      fi
+      mkdir -p "${HOME}/Library/LaunchAgents" 2>/dev/null || true
+      sed -e "s|REPLACEME_MAC_OPS_BIN|${bin_path}|g" \
+          -e "s|REPLACEME_MAC_OPS_HOME|${home_path}|g" \
+          "${plist_src}" > "${plist_dst}"
+      launchctl load "${plist_dst}" 2>/dev/null || true
+      mac_ops_log_info "Monitor launchd agent installed (every 5 min): ${plist_dst}"
+      ;;
+    unsetup)
+      local plist_path="${HOME}/Library/LaunchAgents/com.mac-ops.monitor.plist"
+      if [[ ! -f "${plist_path}" ]]; then
+        mac_ops_log_warn "Monitor launchd agent is not installed."
+        return 0
+      fi
+      launchctl unload "${plist_path}" 2>/dev/null || true
+      rm -f "${plist_path}"
+      mac_ops_log_info "Monitor launchd agent uninstalled"
       ;;
     *)
       # treat unknown subcommand as flag to show (e.g., --hours passed first)

--- a/launchd/com.mac-ops.monitor.plist
+++ b/launchd/com.mac-ops.monitor.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.mac-ops.monitor</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>REPLACEME_MAC_OPS_BIN</string>
+		<string>monitor</string>
+		<string>collect</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>300</integer>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>StandardOutPath</key>
+	<string>REPLACEME_MAC_OPS_HOME/.logs/monitor-stdout.log</string>
+	<key>StandardErrorPath</key>
+	<string>REPLACEME_MAC_OPS_HOME/.logs/monitor-stderr.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
+	</dict>
+</dict>
+</plist>

--- a/lib/core/ignore.zsh
+++ b/lib/core/ignore.zsh
@@ -87,7 +87,8 @@ mac_ops_ignore_check_bundle() {
   local name="${1}"
   local pattern
   for pattern in "${_MAC_OPS_IGNORE_BUNDLES[@]}"; do
-    # ${~pattern} enables glob expansion in the pattern
+    # ${~pattern} enables glob expansion in the pattern (zsh-specific)
+    # shellcheck disable=SC2053,SC2296
     if [[ "${name}" == ${~pattern} ]]; then
       return 0
     fi
@@ -105,6 +106,7 @@ mac_ops_ignore_check_process() {
   local name="${1}"
   local pattern
   for pattern in "${_MAC_OPS_IGNORE_PROCESSES[@]}"; do
+    # shellcheck disable=SC2053,SC2296
     if [[ "${name}" == ${~pattern} ]]; then
       return 0
     fi
@@ -122,7 +124,8 @@ mac_ops_ignore_check_path() {
   local target="${1}"
   local pattern
   for pattern in "${_MAC_OPS_IGNORE_PATHS[@]}"; do
-    # Exact or glob match
+    # Exact or glob match (${~pattern} is zsh-specific glob expansion)
+    # shellcheck disable=SC2053,SC2296
     if [[ "${target}" == ${~pattern} ]]; then
       return 0
     fi

--- a/lib/modules/docker-cleanup.zsh
+++ b/lib/modules/docker-cleanup.zsh
@@ -173,6 +173,7 @@ _mac_ops_docker_parse_size() {
   local number
   local unit
 
+  # shellcheck disable=SC2076
   if [[ "${size_str}" =~ '^([0-9.]+)([KMGT]?B)$' ]]; then
     number="${match[1]}"
     unit="${match[2]}"

--- a/lib/modules/monitor.zsh
+++ b/lib/modules/monitor.zsh
@@ -151,6 +151,7 @@ _mac_ops_monitor_hourly_stats() {
 _mac_ops_monitor_purge_old() {
   local cutoff=$(( $(date +%s) - MAC_OPS_MONITOR_RETENTION_DAYS * 86400 ))
   local f fname epoch
+  # shellcheck disable=SC1036,SC1058,SC1072,SC1073
   for f in "${MAC_OPS_MONITOR_DIR}"/*.csv(N); do
     fname=$(basename "$f" .csv)
     epoch=$(date -j -f '%Y-%m-%d' "$fname" +%s 2>/dev/null || echo 0)

--- a/lib/modules/orphan-app-cleanup.zsh
+++ b/lib/modules/orphan-app-cleanup.zsh
@@ -376,6 +376,7 @@ _mac_ops_scan_preferences() {
 
   mac_ops_log_info "Orphan Preferences scan: ${pref_dir}"
 
+  # shellcheck disable=SC1036,SC1058,SC1072,SC1073
   for plist_file in "${pref_dir}"/*.plist(N); do
     [[ ! -f "${plist_file}" ]] && continue
 


### PR DESCRIPTION
## Summary

- Add `monitor setup` / `monitor unsetup` subcommands to install launchd agent (collect every 5 min)
- Add `launchd/com.mac-ops.monitor.plist` template
- Add `monitor --hours` to help text
- Replace all `bin/mac-ops` with `mac-ops` in README command examples
- Add monitor scheduling docs (cron + launchd) to README

## Test plan

- [ ] `mac-ops monitor setup` installs `com.mac-ops.monitor.plist` to `~/Library/LaunchAgents/`
- [ ] `mac-ops monitor unsetup` removes the agent
- [ ] `mac-ops help` shows new `monitor setup` / `unsetup` / `--hours` entries
- [ ] README command examples use `mac-ops` (not `bin/mac-ops`)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)